### PR TITLE
DROOLS-7278: add Main-Class to MANIFEST.MF of uber-jar

### DIFF
--- a/drools-lsp-server/pom.xml
+++ b/drools-lsp-server/pom.xml
@@ -62,6 +62,11 @@
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>org.drools.lsp.server.Main</mainClass>
+            </manifest>
+          </archive>
         </configuration>
 
         <executions>


### PR DESCRIPTION
DROOLS-7278: add Main-Class to MANIFEST.MF of uber-jar

Signed-off-by: David Ward <dward@redhat.com>