### PR TITLE
[DROOLS-7271] Fully port RuleParserTest as MiscDRLParserTest with @Di…

### DIFF
--- a/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
+++ b/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
@@ -6,11 +6,25 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
+import org.drools.drl.ast.descr.AccumulateDescr;
+import org.drools.drl.ast.descr.AccumulateImportDescr;
 import org.drools.drl.ast.descr.AndDescr;
+import org.drools.drl.ast.descr.AnnotationDescr;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.BaseDescr;
+import org.drools.drl.ast.descr.BehaviorDescr;
+import org.drools.drl.ast.descr.CollectDescr;
+import org.drools.drl.ast.descr.EntryPointDeclarationDescr;
+import org.drools.drl.ast.descr.EntryPointDescr;
+import org.drools.drl.ast.descr.EvalDescr;
+import org.drools.drl.ast.descr.ExistsDescr;
 import org.drools.drl.ast.descr.ExprConstraintDescr;
+import org.drools.drl.ast.descr.ForallDescr;
 import org.drools.drl.ast.descr.FromDescr;
 import org.drools.drl.ast.descr.FunctionDescr;
 import org.drools.drl.ast.descr.GlobalDescr;
@@ -20,7 +34,11 @@ import org.drools.drl.ast.descr.NotDescr;
 import org.drools.drl.ast.descr.OrDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.PatternDescr;
+import org.drools.drl.ast.descr.QueryDescr;
 import org.drools.drl.ast.descr.RuleDescr;
+import org.drools.drl.ast.descr.TypeDeclarationDescr;
+import org.drools.drl.ast.descr.TypeFieldDescr;
+import org.drools.drl.ast.descr.WindowDeclarationDescr;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -29,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
- * This test class is being ported from org.drools.mvel.compiler.lang.RuleParserTest
+ * This test class is ported from org.drools.mvel.compiler.lang.RuleParserTest
  */
 class MiscDRLParserTest {
 
@@ -58,15 +76,32 @@ class MiscDRLParserTest {
         return sb.toString();
     }
 
-    private RuleDescr parseAndGetFirstRule(String drl) {
+    private RuleDescr parseAndGetFirstRuleDescr(String drl) {
         PackageDescr pkg = parser.parse(drl);
         assertThat(parser.hasErrors()).as(parser.getErrorMessages().toString()).isFalse();
         assertThat(pkg.getRules()).isNotEmpty();
         return pkg.getRules().get(0);
     }
 
-    private RuleDescr parseAndGetFirstRuleFromFile(String filename) throws Exception {
-        return parseAndGetFirstRule(readResource(filename));
+    private RuleDescr parseAndGetFirstRuleDescrFromFile(String filename) throws Exception {
+        return parseAndGetFirstRuleDescr(readResource(filename));
+    }
+
+    private PackageDescr parseAndGetPackageDescrFromFile(String filename) throws Exception {
+        return parser.parse(readResource(filename));
+    }
+
+    private QueryDescr parseAndGetFirstQueryDescr(String drl) {
+        PackageDescr pkg = parser.parse(drl);
+        assertThat(parser.hasErrors()).as(parser.getErrorMessages().toString()).isFalse();
+        assertThat(pkg.getRules()).isNotEmpty();
+        Optional<QueryDescr> optQuery = pkg.getRules().stream().filter(QueryDescr.class::isInstance).map(QueryDescr.class::cast).findFirst();
+        assertThat(optQuery).isPresent();
+        return optQuery.get();
+    }
+
+    private QueryDescr parseAndGetFirstQueryDescrFromFile(String filename) throws Exception {
+        return parseAndGetFirstQueryDescr(readResource(filename));
     }
 
     @Test
@@ -624,7 +659,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_literalBoolAndNegativeNumbersRule() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("literal_bool_and_negative.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("literal_bool_and_negative.drl");
 
         assertThat(rule).isNotNull();
 
@@ -678,7 +713,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_simpleMethodCallWithFrom() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("test_SimpleMethodCallWithFrom.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("test_SimpleMethodCallWithFrom.drl");
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         final FromDescr from = (FromDescr) pattern.getSource();
         final MVELExprDescr method = (MVELExprDescr) from.getDataSource();
@@ -688,7 +723,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_simpleFunctionCallWithFrom() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("test_SimpleFunctionCallWithFrom.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("test_SimpleFunctionCallWithFrom.drl");
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         final FromDescr from = (FromDescr) pattern.getSource();
         final MVELExprDescr func = (MVELExprDescr) from.getDataSource();
@@ -698,7 +733,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_simpleAccessorWithFrom() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("test_SimpleAccessorWithFrom.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("test_SimpleAccessorWithFrom.drl");
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
         final FromDescr from = (FromDescr) pattern.getSource();
         final MVELExprDescr accessor = (MVELExprDescr) from.getDataSource();
@@ -708,7 +743,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_simpleAccessorAndArgWithFrom() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("test_SimpleAccessorArgWithFrom.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("test_SimpleAccessorArgWithFrom.drl");
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
         final FromDescr from = (FromDescr) pattern.getSource();
         final MVELExprDescr accessor = (MVELExprDescr) from.getDataSource();
@@ -718,7 +753,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_complexChainedAccessor() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("test_ComplexChainedCallWithFrom.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("test_ComplexChainedCallWithFrom.drl");
 
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
         final FromDescr from = (FromDescr) pattern.getSource();
@@ -729,7 +764,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_from() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("from.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("from.drl");
         assertThat(rule).isNotNull();
 
         assertThat(rule.getName()).isEqualTo("using_from");
@@ -739,7 +774,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_simpleRuleWithBindings() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("simple_rule.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("simple_rule.drl");
         assertThat(rule).isNotNull();
 
         assertThat(rule.getName()).isEqualTo("simple_rule");
@@ -788,7 +823,7 @@ class MiscDRLParserTest {
 
     @Test
     void parse_multipleRestrictionsConstraint() throws Exception {
-        RuleDescr rule = parseAndGetFirstRuleFromFile("restrictions_test.drl");
+        RuleDescr rule = parseAndGetFirstRuleDescrFromFile("restrictions_test.drl");
         assertThat(rule).isNotNull();
 
         assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace("consequence();");
@@ -819,4 +854,2433 @@ class MiscDRLParserTest {
         fld = (ExprConstraintDescr) and.getDescrs().get( 1 );
         assertThat(fld.getExpression()).isEqualToIgnoringWhitespace( "age < 3");
     }
+
+//-------------------------------------------------------------------------
+// DROOLS-7271 : ported from RuleParserTest
+// Failing tests are annotated with @Disabled. We can fix issues one by one
+//-------------------------------------------------------------------------
+
+    @Disabled("Priority : Mid | implement Descr lineNumber")
+    @Test
+    public void parse_LineNumberInAST() throws Exception {
+        // also see testSimpleExpander to see how this works with an expander
+        // (should be the same).
+
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "simple_rule.drl" );
+
+        assertThat(rule).isNotNull();
+
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        assertThat(rule.getConsequenceLine()).isEqualTo(22);
+        assertThat(rule.getConsequencePattern()).isEqualTo(2);
+
+        final AndDescr lhs = rule.getLhs();
+
+        assertThat(lhs).isNotNull();
+
+        assertThat(lhs.getDescrs().size()).isEqualTo(3);
+
+        // Check first pattern
+        final PatternDescr first = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(first.getIdentifier()).isEqualTo("foo3");
+        assertThat(first.getObjectType()).isEqualTo("Bar");
+        assertThat(first.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        // Check second pattern
+        final PatternDescr second = (PatternDescr) lhs.getDescrs().get( 1 );
+        assertThat(second.getIdentifier()).isEqualTo("foo4");
+        assertThat(second.getObjectType()).isEqualTo("Bar");
+
+        final PatternDescr third = (PatternDescr) lhs.getDescrs().get( 2 );
+        assertThat(third.getObjectType()).isEqualTo("Baz");
+
+        assertThat(first.getLine()).isEqualTo(19);
+        assertThat(second.getLine()).isEqualTo(20);
+        assertThat(third.getLine()).isEqualTo(21);
+    }
+
+    @Disabled("Priority : High | Failed to parse comments in RHS")
+    @Test
+    public void parse_LineNumberIncludingCommentsInRHS() throws Exception {
+        PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                         "test_CommentLineNumbersInConsequence.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        final String rhs = (String) ((RuleDescr) pkg.getRules().get( 0 )).getConsequence();
+        String expected = "\\s*//woot$\\s*first$\\s*$\\s*//$\\s*$\\s*/\\* lala$\\s*$\\s*\\*/$\\s*second$\\s*";
+        assertThat(Pattern.compile(expected,
+                                   Pattern.DOTALL | Pattern.MULTILINE).matcher(rhs).matches()).isTrue();
+    }
+
+    @Disabled("Priority : High | Implement semicolon delimiter")
+    @Test
+    public void parse_LhsSemicolonDelim() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "lhs_semicolon_delim.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(rule).isNotNull();
+
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        final AndDescr lhs = rule.getLhs();
+
+        assertThat(lhs).isNotNull();
+
+        assertThat(lhs.getDescrs().size()).isEqualTo(3);
+
+        // System.err.println( lhs.getDescrs() );
+
+        // Check first pattern
+        final PatternDescr first = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(first.getIdentifier()).isEqualTo("foo3");
+        assertThat(first.getObjectType()).isEqualTo("Bar");
+
+        assertThat(first.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        // LiteralDescr constraint = (LiteralDescr) first.getDescrs().get( 0 );
+        AndDescr and = (AndDescr) first.getConstraint();
+        ExprConstraintDescr fld = (ExprConstraintDescr) and.getDescrs().get( 0 );
+        assertThat(fld).isNotNull();
+
+        assertThat(fld.getExpression()).isEqualTo("a==3");
+
+        // Check second pattern
+        final PatternDescr second = (PatternDescr) lhs.getDescrs().get( 1 );
+        assertThat(second.getIdentifier()).isEqualTo("foo4");
+        assertThat(second.getObjectType()).isEqualTo("Bar");
+
+        assertThat(second.getDescrs().size()).isEqualTo(1);
+
+        final ExprConstraintDescr fieldBindingDescr = (ExprConstraintDescr) second.getDescrs().get( 0 );
+        assertThat(fieldBindingDescr.getExpression()).isEqualTo("a4:a==4");
+
+        // Check third pattern
+        final PatternDescr third = (PatternDescr) lhs.getDescrs().get( 2 );
+        assertThat(third.getIdentifier()).isNull();
+        assertThat(third.getObjectType()).isEqualTo("Baz");
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace("if ( a == b ) { " + "  assert( foo3 );" + "} else {" + "  retract( foo4 );" + "}" + "  System.out.println( a4 );");
+    }
+
+    @Test
+    public void parse_NotNode() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_not.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(rule).isNotNull();
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        final AndDescr lhs = rule.getLhs();
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+        final NotDescr not = (NotDescr) lhs.getDescrs().get( 0 );
+        assertThat(not.getDescrs().size()).isEqualTo(1);
+        final PatternDescr pattern = (PatternDescr) not.getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        final AndDescr and = (AndDescr) pattern.getConstraint();
+        final ExprConstraintDescr fld = (ExprConstraintDescr) and.getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualTo("type == \"stilton\"");
+    }
+
+    @Test
+    public void parse_NotExistWithBrackets() throws Exception {
+
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "not_exist_with_brackets.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        assertThat(rule).isNotNull();
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        final AndDescr lhs = rule.getLhs();
+        assertThat(lhs.getDescrs().size()).isEqualTo(2);
+        final NotDescr not = (NotDescr) lhs.getDescrs().get( 0 );
+        assertThat(not.getDescrs().size()).isEqualTo(1);
+        final PatternDescr pattern = (PatternDescr) not.getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+
+        final ExistsDescr ex = (ExistsDescr) lhs.getDescrs().get(1 );
+        assertThat(ex.getDescrs().size()).isEqualTo(1);
+        final PatternDescr exPattern = (PatternDescr) ex.getDescrs().get( 0 );
+        assertThat(exPattern.getObjectType()).isEqualTo("Foo");
+    }
+
+    @Disabled("Priority : High | Implement query")
+    @Test
+    public void parse_SimpleQuery() throws Exception {
+        final QueryDescr query = parseAndGetFirstQueryDescrFromFile(
+                                                            "simple_query.drl" );
+
+        assertThat(query).isNotNull();
+
+        assertThat(query.getName()).isEqualTo("simple_query");
+
+        final AndDescr lhs = query.getLhs();
+
+        assertThat(lhs).isNotNull();
+
+        assertThat(lhs.getDescrs().size()).isEqualTo(3);
+
+        // Check first pattern
+        final PatternDescr first = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(first.getIdentifier()).isEqualTo("foo3");
+        assertThat(first.getObjectType()).isEqualTo("Bar");
+
+        assertThat(first.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        AndDescr and = (AndDescr) first.getConstraint();
+        ExprConstraintDescr fld = (ExprConstraintDescr) and.getDescrs().get( 0 );
+        assertThat(fld).isNotNull();
+
+        assertThat(fld.getExpression()).isEqualTo("a==3");
+
+        // Check second pattern
+        final PatternDescr second = (PatternDescr) lhs.getDescrs().get( 1 );
+        assertThat(second.getIdentifier()).isEqualTo("foo4");
+        assertThat(second.getObjectType()).isEqualTo("Bar");
+
+        assertThat(second.getDescrs().size()).isEqualTo(1);
+        // check it has field bindings.
+        final ExprConstraintDescr bindingDescr = (ExprConstraintDescr) second.getDescrs().get( 0 );
+        assertThat(bindingDescr.getExpression()).isEqualTo("a4:a==4");
+    }
+
+    @Disabled("Priority : High | Implement query")
+    @Test
+    public void parse_QueryRuleMixed() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "query_and_rule.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(4); // as queries are rules
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getName()).isEqualTo("bar");
+
+        QueryDescr query = (QueryDescr) pkg.getRules().get( 1 );
+        assertThat(query.getName()).isEqualTo("simple_query");
+
+        rule = (RuleDescr) pkg.getRules().get( 2 );
+        assertThat(rule.getName()).isEqualTo("bar2");
+
+        query = (QueryDescr) pkg.getRules().get( 3 );
+        assertThat(query.getName()).isEqualTo("simple_query2");
+    }
+
+    @Test
+    public void parse_MultipleRules() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "multiple_rules.drl" );
+
+        final List<RuleDescr> rules = pkg.getRules();
+
+        assertThat(rules.size()).isEqualTo(2);
+
+        final RuleDescr rule0 = rules.get( 0 );
+        assertThat(rule0.getName()).isEqualTo("Like Stilton");
+
+        final RuleDescr rule1 = rules.get( 1 );
+        assertThat(rule1.getName()).isEqualTo("Like Cheddar");
+
+        // checkout the first rule
+        AndDescr lhs = rule1.getLhs();
+        assertThat(lhs).isNotNull();
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+        assertThat((String) rule0.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println(\"I like \" + t);");
+
+        // Check first pattern
+        PatternDescr first = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(first.getObjectType()).isEqualTo("Cheese");
+
+        // checkout the second rule
+        lhs = rule1.getLhs();
+        assertThat(lhs).isNotNull();
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+        assertThat((String) rule1.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println(\"I like \" + t);");
+
+        // Check first pattern
+        first = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(first.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : low | Not yet support DSL")
+    @Test
+    public void parse_ExpanderLineSpread() throws Exception {
+//        final DrlParser parser = new DrlParser(LanguageLevelOption.DRL6);
+//        final PackageDescr pkg = parser.parse( this.getReader( "expander_spread_lines.dslr" ),
+//                                               this.getReader( "complex.dsl" ) );
+//
+//        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+//
+//        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+//        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+//
+//        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 0 );
+//        assertThat(or.getDescrs().size()).isEqualTo(2);
+//        assertThat( (String) rule.getConsequence() ).isNotNull();
+
+    }
+
+    @Disabled("Priority : low | Not yet support DSL")
+    @Test
+    public void parse_ExpanderMultipleConstraints() throws Exception {
+//        final DrlParser parser = new DrlParser(LanguageLevelOption.DRL6);
+//        final PackageDescr pkg = parser.parse( this.getReader( "expander_multiple_constraints.dslr" ),
+//                                               this.getReader( "multiple_constraints.dsl" ) );
+//
+//        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+//
+//        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+//        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+//
+//        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+//        assertThat(pattern.getObjectType()).isEqualTo("Person");
+//
+//        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(2);
+//        assertThat(((ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0)).getExpression()).isEqualTo("age < 42");
+//        assertThat(((ExprConstraintDescr) pattern.getConstraint().getDescrs().get(1)).getExpression()).isEqualTo("location==atlanta");
+//
+//        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+//        assertThat(pattern.getObjectType()).isEqualTo("Bar");
+//
+//        assertThat( (String) rule.getConsequence() ).isNotNull();
+
+    }
+
+    @Disabled("Priority : low | Not yet support DSL")
+    @Test
+    public void parse_ExpanderMultipleConstraintsFlush() throws Exception {
+//        final DrlParser parser = new DrlParser(LanguageLevelOption.DRL6);
+//        // this is similar to the other test, but it requires a flush to add the
+//        // constraints
+//        final PackageDescr pkg = parser.parse( this.getReader( "expander_multiple_constraints_flush.dslr" ),
+//                                               this.getReader( "multiple_constraints.dsl" ) );
+//
+//        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+//
+//        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+//        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+//
+//        final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+//        assertThat(pattern.getObjectType()).isEqualTo("Person");
+//
+//        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(2);
+//        assertThat(((ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0)).getExpression()).isEqualTo("age < 42");
+//        assertThat(((ExprConstraintDescr) pattern.getConstraint().getDescrs().get(1)).getExpression()).isEqualTo("location==atlanta");
+//
+//        assertThat( (String) rule.getConsequence() ).isNotNull();
+
+    }
+
+    @Test
+    public void parse_BasicBinding() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "basic_binding.drl" );
+
+        final RuleDescr ruleDescr = (RuleDescr) pkg.getRules().get( 0 );
+
+        final AndDescr lhs = ruleDescr.getLhs();
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+        final PatternDescr cheese = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+        assertThat(cheese.getConstraint().getDescrs().size()).isEqualTo(1);
+        final ExprConstraintDescr fieldBinding = (ExprConstraintDescr) cheese.getDescrs().get( 0 );
+        assertThat(fieldBinding.getExpression()).isEqualToIgnoringWhitespace("$type:type");
+    }
+
+    @Test
+    public void parse_BoundVariables() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "bindings.drl" );
+
+        final RuleDescr ruleDescr = (RuleDescr) pkg.getRules().get( 0 );
+
+        final AndDescr lhs = ruleDescr.getLhs();
+        assertThat(lhs.getDescrs().size()).isEqualTo(2);
+        final PatternDescr cheese = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+        assertThat(cheese.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fieldBinding = (ExprConstraintDescr) cheese.getDescrs().get( 0 );
+        assertThat(fieldBinding.getExpression()).isEqualTo("$type : type == \"stilton\"");
+
+        final PatternDescr person = (PatternDescr) lhs.getDescrs().get( 1 );
+        assertThat(person.getDescrs().size()).isEqualTo(2);
+        fieldBinding = (ExprConstraintDescr) person.getDescrs().get( 0 );
+        assertThat(fieldBinding.getExpression()).isEqualTo("$name : name == \"bob\"");
+
+        ExprConstraintDescr fld = (ExprConstraintDescr) person.getDescrs().get( 1 );
+        assertThat(fld.getExpression()).isEqualTo("likes == $type");
+    }
+
+    @Disabled("Priority : High | Failed to parse and/or with parentheses in LHS")
+    @Test
+    public void parse_OrNesting() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "or_nesting.drl" );
+
+        assertThat(pkg).isNotNull();
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+
+        final PatternDescr first = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(first.getObjectType()).isEqualTo("Person");
+
+        final AndDescr and = (AndDescr) or.getDescrs().get( 1 );
+        assertThat(and.getDescrs().size()).isEqualTo(2);
+
+        final PatternDescr left = (PatternDescr) and.getDescrs().get( 0 );
+        assertThat(left.getObjectType()).isEqualTo("Person");
+
+        final PatternDescr right = (PatternDescr) and.getDescrs().get( 1 );
+        assertThat(right.getObjectType()).isEqualTo("Cheese");
+    }
+
+    /** Test that explicit "&&", "||" works as expected */
+    @Test
+    public void parse_AndOrRules() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "and_or_rule.drl" );
+
+        assertThat(pkg).isNotNull();
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+
+        // we will have 3 children under the main And node
+        final AndDescr and = rule.getLhs();
+        assertThat(and.getDescrs().size()).isEqualTo(3);
+
+        PatternDescr left = (PatternDescr) and.getDescrs().get( 0 );
+        PatternDescr right = (PatternDescr) and.getDescrs().get( 1 );
+        assertThat(left.getObjectType()).isEqualTo("Person");
+        assertThat(right.getObjectType()).isEqualTo("Cheese");
+
+        assertThat(left.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        ExprConstraintDescr fld = (ExprConstraintDescr) left.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualTo("name == \"mark\"");
+
+        assertThat(right.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        fld = (ExprConstraintDescr) right.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualTo("type == \"stilton\"");
+
+        // now the "||" part
+        final OrDescr or = (OrDescr) and.getDescrs().get( 2 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+        left = (PatternDescr) or.getDescrs().get( 0 );
+        right = (PatternDescr) or.getDescrs().get( 1 );
+        assertThat(left.getObjectType()).isEqualTo("Person");
+        assertThat(right.getObjectType()).isEqualTo("Cheese");
+        assertThat(left.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        fld = (ExprConstraintDescr) left.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualTo("name == \"mark\"");
+
+        assertThat(right.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        fld = (ExprConstraintDescr) right.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualTo("type == \"stilton\"");
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println( \"Mark and Michael\" );");
+    }
+
+    /** test basic foo : Fact() || Fact() stuff */
+    @Test
+    public void parse_OrWithBinding() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "or_binding.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+
+        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+
+        final PatternDescr leftPattern = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(leftPattern.getObjectType()).isEqualTo("Person");
+        assertThat(leftPattern.getIdentifier()).isEqualTo("foo");
+
+        final PatternDescr rightPattern = (PatternDescr) or.getDescrs().get( 1 );
+        assertThat(rightPattern.getObjectType()).isEqualTo("Person");
+        assertThat(rightPattern.getIdentifier()).isEqualTo("foo");
+
+        final PatternDescr cheeseDescr = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(cheeseDescr.getObjectType()).isEqualTo("Cheese");
+        assertThat(cheeseDescr.getIdentifier()).isEqualTo(null);
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println( \"Mark and Michael\" + bar );");
+    }
+
+    /** test basic foo : Fact() || Fact() stuff binding to an "or" */
+    @Test
+    public void parse_OrBindingComplex() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "or_binding_complex.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+
+        // first fact
+        final PatternDescr firstFact = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(firstFact.getObjectType()).isEqualTo("Person");
+        assertThat(firstFact.getIdentifier()).isEqualTo("foo");
+
+        // second "option"
+        final PatternDescr secondFact = (PatternDescr) or.getDescrs().get( 1 );
+        assertThat(secondFact.getObjectType()).isEqualTo("Person");
+        assertThat(secondFact.getConstraint().getDescrs().size()).isEqualTo(1);
+        assertThat(secondFact.getIdentifier()).isEqualTo("foo");
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println( \"Mark and Michael\" + bar );");
+    }
+
+    @Test
+    public void parse_OrBindingWithBrackets() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "or_binding_with_brackets.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+
+        // first fact
+        final PatternDescr firstFact = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(firstFact.getObjectType()).isEqualTo("Person");
+        assertThat(firstFact.getIdentifier()).isEqualTo("foo");
+
+        // second "option"
+        final PatternDescr secondFact = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(secondFact.getObjectType()).isEqualTo("Person");
+        assertThat(secondFact.getIdentifier()).isEqualTo("foo");
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println( \"Mark and Michael\" + bar );");
+    }
+
+    @Disabled("Priority : High | Failed to parse complex parentheses")
+    @Test
+    public void parse_BracketsPrecedence() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "brackets_precedence.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        final AndDescr rootAnd = (AndDescr) rule.getLhs();
+
+        assertThat(rootAnd.getDescrs().size()).isEqualTo(2);
+
+        final OrDescr leftOr = (OrDescr) rootAnd.getDescrs().get( 0 );
+
+        assertThat(leftOr.getDescrs().size()).isEqualTo(2);
+        final NotDescr not = (NotDescr) leftOr.getDescrs().get( 0 );
+        final PatternDescr foo1 = (PatternDescr) not.getDescrs().get( 0 );
+        assertThat(foo1.getObjectType()).isEqualTo("Foo");
+        final PatternDescr foo2 = (PatternDescr) leftOr.getDescrs().get( 1 );
+        assertThat(foo2.getObjectType()).isEqualTo("Foo");
+
+        final OrDescr rightOr = (OrDescr) rootAnd.getDescrs().get( 1 );
+
+        assertThat(rightOr.getDescrs().size()).isEqualTo(2);
+        final PatternDescr shoes = (PatternDescr) rightOr.getDescrs().get( 0 );
+        assertThat(shoes.getObjectType()).isEqualTo("Shoes");
+        final PatternDescr butt = (PatternDescr) rightOr.getDescrs().get( 1 );
+        assertThat(butt.getObjectType()).isEqualTo("Butt");
+    }
+
+    @Disabled("Priority : High | Implement eval")
+    @Test
+    public void parse_EvalMultiple() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "eval_multiple.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(4);
+
+        final EvalDescr eval = (EvalDescr) rule.getLhs().getDescrs().get(0 );
+        assertThat((String) eval.getContent()).isEqualToIgnoringWhitespace( "abc(\"foo\") + 5");
+
+        final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("Foo");
+
+    }
+
+    @Disabled("Priority : High | Implement eval")
+    @Test
+    public void parse_WithEval() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "with_eval.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(3);
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("Foo");
+        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("Bar");
+
+        final EvalDescr eval = (EvalDescr) rule.getLhs().getDescrs().get( 2 );
+        assertThat((String) eval.getContent()).isEqualToIgnoringWhitespace( "abc(\"foo\")");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "Kapow");
+    }
+
+    @Test
+    public void parse_WithRetval() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "with_retval.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        final PatternDescr col = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(col.getConstraint().getDescrs().size()).isEqualTo(1);
+        assertThat(col.getObjectType()).isEqualTo("Foo");
+        final ExprConstraintDescr fld = (ExprConstraintDescr) col.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("name== (a + b)");
+    }
+
+    @Test
+    public void parse_WithPredicate() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "with_predicate.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        final PatternDescr col = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        AndDescr and = (AndDescr) col.getConstraint();
+        assertThat(and.getDescrs().size()).isEqualTo(2);
+
+        final ExprConstraintDescr field = (ExprConstraintDescr) col.getDescrs().get( 0 );
+        final ExprConstraintDescr pred = (ExprConstraintDescr) and.getDescrs().get( 1 );
+        assertThat(field.getExpression()).isEqualToIgnoringWhitespace("$age2:age");
+        assertThat(pred.getExpression()).isEqualToIgnoringWhitespace( "$age2 == $age1+2");
+    }
+
+    @Test
+    public void parse_NotWithConstraint() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "not_with_constraint.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final ExprConstraintDescr fieldBinding = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fieldBinding.getExpression()).isEqualToIgnoringWhitespace("$likes:like");
+
+        final NotDescr not = (NotDescr) rule.getLhs().getDescrs().get( 1 );
+        pattern = (PatternDescr) not.getDescrs().get( 0 );
+
+        final ExprConstraintDescr fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("type == $likes");
+    }
+
+    @Disabled("Priority : Mid | Implement Descr lineNumber")
+    @Test
+    public void parse_Functions() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "functions.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(2);
+
+        final List<FunctionDescr> functions = pkg.getFunctions();
+        assertThat(functions.size()).isEqualTo(2);
+
+        FunctionDescr func = functions.get( 0 );
+        assertThat(func.getName()).isEqualTo("functionA");
+        assertThat(func.getReturnType()).isEqualTo("String");
+        assertThat(func.getParameterNames().size()).isEqualTo(2);
+        assertThat(func.getParameterTypes().size()).isEqualTo(2);
+        assertThat(func.getLine()).isEqualTo(19);
+        assertThat(func.getColumn()).isEqualTo(0);
+
+        assertThat(func.getParameterTypes().get(0)).isEqualTo("String");
+        assertThat(func.getParameterNames().get(0)).isEqualTo("s");
+
+        assertThat(func.getParameterTypes().get(1)).isEqualTo("Integer");
+        assertThat(func.getParameterNames().get(1)).isEqualTo("i");
+
+        assertThat(func.getBody()).isEqualToIgnoringWhitespace( "foo();");
+
+        func = functions.get( 1 );
+        assertThat(func.getName()).isEqualTo("functionB");
+        assertThat(func.getText()).isEqualToIgnoringWhitespace( "bar();");
+    }
+
+    @Test
+    public void parse_Comment() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "comment.drl" );
+
+        assertThat(pkg).isNotNull();
+
+        assertThat(pkg.getName()).isEqualTo("foo.bar");
+    }
+
+    @Disabled("Priority : High | Parse attribute without value => true")
+    @Test
+    public void parse_Attributes() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_attributes.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(6);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "salience" );
+        assertThat(at.getName()).isEqualTo("salience");
+        assertThat(at.getValue()).isEqualTo("42");
+
+        at = (AttributeDescr) attrs.get( "agenda-group" );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("my_group");
+
+        at = (AttributeDescr) attrs.get( "no-loop" );
+        assertThat(at.getName()).isEqualTo("no-loop");
+        assertThat(at.getValue()).isEqualTo("true");
+
+        at = (AttributeDescr) attrs.get( "duration" );
+        assertThat(at.getName()).isEqualTo("duration");
+        assertThat(at.getValue()).isEqualTo("42");
+
+        at = (AttributeDescr) attrs.get( "activation-group" );
+        assertThat(at.getName()).isEqualTo("activation-group");
+        assertThat(at.getValue()).isEqualTo("my_activation_group");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : High | Parse attribute with parentheses")
+    @Test
+    public void parse_Attributes2() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "rule_attributes2.drl" );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        List<RuleDescr> rules = pkg.getRules();
+        assertThat(rules.size()).isEqualTo(3);
+
+        RuleDescr rule = rules.get( 0 );
+        assertThat(rule.getName()).isEqualTo("rule1");
+        Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+        AttributeDescr at = (AttributeDescr) attrs.get( "salience" );
+        assertThat(at.getName()).isEqualTo("salience");
+        assertThat(at.getValue()).isEqualTo("(42)");
+        at = (AttributeDescr) attrs.get( "agenda-group" );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("my_group");
+
+        rule = rules.get( 1 );
+        assertThat(rule.getName()).isEqualTo("rule2");
+        attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+        at = (AttributeDescr) attrs.get( "salience" );
+        assertThat(at.getName()).isEqualTo("salience");
+        assertThat(at.getValue()).isEqualTo("(Integer.MIN_VALUE)");
+        at = (AttributeDescr) attrs.get( "no-loop" );
+        assertThat(at.getName()).isEqualTo("no-loop");
+
+        rule = rules.get( 2 );
+        assertThat(rule.getName()).isEqualTo("rule3");
+        attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+        at = (AttributeDescr) attrs.get( "enabled" );
+        assertThat(at.getName()).isEqualTo("enabled");
+        assertThat(at.getValue()).isEqualTo("(Boolean.TRUE)");
+        at = (AttributeDescr) attrs.get( "activation-group" );
+        assertThat(at.getName()).isEqualTo("activation-group");
+        assertThat(at.getValue()).isEqualTo("my_activation_group");
+
+    }
+
+    @Disabled("Priority : High | Parse attribute without value => true")
+    @Test
+    public void parse_AttributeRefract() throws Exception {
+        final String source = "rule Test refract when Person() then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 source );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        assertThat(rule.getName()).isEqualTo("Test");
+        Map<String, AttributeDescr> attributes = rule.getAttributes();
+        assertThat(attributes.size()).isEqualTo(1);
+        AttributeDescr refract = attributes.get( "refract" );
+        assertThat(refract).isNotNull();
+        assertThat(refract.getValue()).isEqualTo("true");
+
+    }
+
+    @Disabled("Priority : High | Parse attribute with parentheses")
+    @Test
+    public void parse_EnabledExpression() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_enabled_expression.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(3);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "enabled" );
+        assertThat(at.getName()).isEqualTo("enabled");
+        assertThat(at.getValue()).isEqualTo("( 1 + 1 == 2 )");
+
+        at = (AttributeDescr) attrs.get( "salience" );
+        assertThat(at.getName()).isEqualTo("salience");
+        assertThat(at.getValue()).isEqualTo("( 1+2 )");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : High | Parse attribute with parentheses")
+    @Test
+    public void parse_DurationExpression() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_duration_expression.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "duration" );
+        assertThat(at.getName()).isEqualTo("duration");
+        assertThat(at.getValue()).isEqualTo("1h30m");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : Mid | Parse calendar attribute")
+    @Test
+    public void parse_Calendars() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_calendars_attribute.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "calendars" );
+        assertThat(at.getName()).isEqualTo("calendars");
+        assertThat(at.getValue()).isEqualTo("[ \"cal1\" ]");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : Mid | Parse calendar attribute")
+    @Test
+    public void parse_Calendars2() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_calendars_attribute2.drl" );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(2);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "calendars" );
+        assertThat(at.getName()).isEqualTo("calendars");
+        assertThat(at.getValue()).isEqualTo("[ \"cal 1\", \"cal 2\", \"cal 3\" ]");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : Low | Not written in docs nor other unit tests. Drop the support?")
+    @Test
+    public void parse_Attributes_alternateSyntax() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "rule_attributes_alt.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "bar();");
+
+        final Map<String, AttributeDescr> attrs = rule.getAttributes();
+        assertThat(attrs.size()).isEqualTo(6);
+
+        AttributeDescr at = (AttributeDescr) attrs.get( "salience" );
+        assertThat(at.getName()).isEqualTo("salience");
+        assertThat(at.getValue()).isEqualTo("42");
+
+        at = (AttributeDescr) attrs.get( "agenda-group" );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("my_group");
+
+        at = (AttributeDescr) attrs.get( "no-loop" );
+        assertThat(at.getName()).isEqualTo("no-loop");
+        assertThat(at.getValue()).isEqualTo("true");
+
+        at = (AttributeDescr) attrs.get( "lock-on-active" );
+        assertThat(at.getName()).isEqualTo("lock-on-active");
+        assertThat(at.getValue()).isEqualTo("true");
+
+        at = (AttributeDescr) attrs.get( "duration" );
+        assertThat(at.getName()).isEqualTo("duration");
+        assertThat(at.getValue()).isEqualTo("42");
+
+        at = (AttributeDescr) attrs.get( "activation-group" );
+        assertThat(at.getName()).isEqualTo("activation-group");
+        assertThat(at.getValue()).isEqualTo("my_activation_group");
+    }
+
+    @Test
+    public void parse_Enumeration() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                           "enumeration.drl" );
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        final PatternDescr col = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(col.getObjectType()).isEqualTo("Foo");
+        assertThat(col.getConstraint().getDescrs().size()).isEqualTo(1);
+        final ExprConstraintDescr fld = (ExprConstraintDescr) col.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("bar == Foo.BAR");
+    }
+
+    @Test
+    public void parse_ExtraLhsNewline() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                       "extra_lhs_newline.drl" );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+    }
+
+    @Disabled("Priority : Low | Implement soundslike")
+    @Test
+    public void parse_SoundsLike() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "soundslike_operator.drl" );
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        PatternDescr pat = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+
+        pat.getConstraint();
+    }
+
+    @Disabled("Priority : High | Parse attribute agenda-group")
+    @Test
+    public void parse_PackageAttributes() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "package_attributes.drl" );
+
+        AttributeDescr at = (AttributeDescr) pkg.getAttributes().get( 0 );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("x");
+        at = (AttributeDescr) pkg.getAttributes().get( 1 );
+        assertThat(at.getName()).isEqualTo("dialect");
+        assertThat(at.getValue()).isEqualTo("java");
+
+        assertThat(pkg.getRules().size()).isEqualTo(2);
+
+        assertThat(pkg.getImports().size()).isEqualTo(2);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getName()).isEqualTo("bar");
+        at = (AttributeDescr) rule.getAttributes().get( "agenda-group" );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("x");
+        at = (AttributeDescr) rule.getAttributes().get( "dialect" );
+        assertThat(at.getName()).isEqualTo("dialect");
+        assertThat(at.getValue()).isEqualTo("java");
+
+        rule = (RuleDescr) pkg.getRules().get( 1 );
+        assertThat(rule.getName()).isEqualTo("baz");
+        at = (AttributeDescr) rule.getAttributes().get( "dialect" );
+        assertThat(at.getName()).isEqualTo("dialect");
+        assertThat(at.getValue()).isEqualTo("mvel");
+        at = (AttributeDescr) rule.getAttributes().get( "agenda-group" );
+        assertThat(at.getName()).isEqualTo("agenda-group");
+        assertThat(at.getValue()).isEqualTo("x");
+
+    }
+
+    @Test
+    public void parse_StatementOrdering1() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "statement_ordering_1.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(2);
+
+        assertThat(((RuleDescr) pkg.getRules().get(0)).getName()).isEqualTo("foo");
+        assertThat(((RuleDescr) pkg.getRules().get(1)).getName()).isEqualTo("bar");
+
+        assertThat(pkg.getFunctions().size()).isEqualTo(2);
+
+        assertThat(((FunctionDescr) pkg.getFunctions().get(0)).getName()).isEqualTo("cheeseIt");
+        assertThat(((FunctionDescr) pkg.getFunctions().get(1)).getName()).isEqualTo("uncheeseIt");
+
+        assertThat(pkg.getImports().size()).isEqualTo(4);
+        assertThat(((ImportDescr) pkg.getImports().get(0)).getTarget()).isEqualTo("im.one");
+        assertThat(((ImportDescr) pkg.getImports().get(1)).getTarget()).isEqualTo("im.two");
+        assertThat(((ImportDescr) pkg.getImports().get(2)).getTarget()).isEqualTo("im.three");
+        assertThat(((ImportDescr) pkg.getImports().get(3)).getTarget()).isEqualTo("im.four");
+    }
+
+    @Test
+    public void parse_RuleNamesStartingWithNumbers() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "rule_names_number_prefix.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(2);
+
+        assertThat(((RuleDescr) pkg.getRules().get(0)).getName()).isEqualTo("1. Do Stuff!");
+        assertThat(((RuleDescr) pkg.getRules().get(1)).getName()).isEqualTo("2. Do More Stuff!");
+    }
+
+    @Test
+    public void parse_EvalWithNewline() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                                 "eval_with_newline.drl");
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+    }
+
+    @Disabled("Priority : Mid | implement Descr lineNumber")
+    @Test
+    public void parse_EndPosition() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "test_EndPosition.drl" );
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        final PatternDescr col = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(col.getLine()).isEqualTo(21);
+        assertThat(col.getEndLine()).isEqualTo(23);
+    }
+
+    @Test
+    public void parse_QualifiedClassname() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "qualified_classname.drl" );
+
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        final PatternDescr p = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+
+        assertThat(p.getObjectType()).isEqualTo("com.cheeseco.Cheese");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_Accumulate() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulate.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr outPattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accum = (AccumulateDescr) outPattern.getSource();
+        assertThat(accum.getInitCode()).isEqualToIgnoringWhitespace( "int x = 0 ;");
+        assertThat(accum.getActionCode()).isEqualToIgnoringWhitespace( "x++;");
+        assertThat(accum.getReverseCode()).isNull();
+        assertThat(accum.getResultCode()).isEqualToIgnoringWhitespace( "new Integer(x)");
+
+        assertThat(accum.isExternalFunction()).isFalse();
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateWithBindings() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulate_with_bindings.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr outPattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accum = (AccumulateDescr) outPattern.getSource();
+        assertThat(outPattern.getIdentifier()).isEqualToIgnoringWhitespace( "$counter");
+        assertThat(accum.getInitCode()).isEqualToIgnoringWhitespace( "int x = 0 ;");
+        assertThat(accum.getActionCode()).isEqualToIgnoringWhitespace( "x++;");
+        assertThat(accum.getResultCode()).isEqualToIgnoringWhitespace( "new Integer(x)");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+    }
+
+    @Disabled("Priority : High | Implement from collect")
+    @Test
+    public void parse_Collect() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "collect.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr outPattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final CollectDescr collect = (CollectDescr) outPattern.getSource();
+
+        final PatternDescr pattern = (PatternDescr) collect.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+    }
+
+    @Test
+    public void parse_Predicate2() throws Exception {
+        // predicates are also prefixed by the eval keyword
+        final RuleDescr rule = parseAndGetFirstRuleDescr(
+                                                  "rule X when Foo(eval( $var.equals(\"xyz\") )) then end" );
+
+        final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final List< ? > constraints = pattern.getConstraint().getDescrs();
+        assertThat(constraints.size()).isEqualTo(1);
+
+        final ExprConstraintDescr predicate = (ExprConstraintDescr) constraints.get( 0 );
+        assertThat(predicate.getExpression()).isEqualToIgnoringWhitespace("eval( $var.equals(\"xyz\") )");
+    }
+
+    @Test
+    public void parse_EscapedStrings() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "escaped-string.drl" );
+
+        assertThat(rule).isNotNull();
+
+        assertThat(rule.getName()).isEqualTo("test_Quotes");
+
+        final String expected = "String s = \"\\\"\\n\\t\\\\\";";
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( expected);
+    }
+
+    @Disabled("Priority : High | parse nested parentheses")
+    @Test
+    public void parse_NestedCEs() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "nested_conditional_elements.drl" );
+
+        assertThat(rule).isNotNull();
+
+        final AndDescr root = rule.getLhs();
+        final NotDescr not1 = (NotDescr) root.getDescrs().get( 0 );
+        final AndDescr and1 = (AndDescr) not1.getDescrs().get( 0 );
+
+        final PatternDescr state = (PatternDescr) and1.getDescrs().get( 0 );
+        final NotDescr not2 = (NotDescr) and1.getDescrs().get( 1 );
+        final AndDescr and2 = (AndDescr) not2.getDescrs().get( 0 );
+        final PatternDescr person = (PatternDescr) and2.getDescrs().get( 0 );
+        final PatternDescr cheese = (PatternDescr) and2.getDescrs().get( 1 );
+
+        final PatternDescr person2 = (PatternDescr) root.getDescrs().get( 1 );
+        final OrDescr or = (OrDescr) root.getDescrs().get( 2 );
+        final PatternDescr cheese2 = (PatternDescr) or.getDescrs().get( 0 );
+        final PatternDescr cheese3 = (PatternDescr) or.getDescrs().get( 1 );
+
+        assertThat("State").isEqualTo(state.getObjectType());
+        assertThat("Person").isEqualTo(person.getObjectType());
+        assertThat("Cheese").isEqualTo(cheese.getObjectType());
+        assertThat("Person").isEqualTo(person2.getObjectType());
+        assertThat("Cheese").isEqualTo(cheese2.getObjectType());
+        assertThat("Cheese").isEqualTo(cheese3.getObjectType());
+    }
+
+    @Disabled("Priority : High | Implement forall")
+    @Test
+    public void parse_Forall() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "forall.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final ForallDescr forall = (ForallDescr) rule.getLhs().getDescrs().get(0 );
+
+        assertThat(forall.getDescrs().size()).isEqualTo(2);
+        final PatternDescr pattern = forall.getBasePattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        final List<BaseDescr> remaining = forall.getRemainingPatterns();
+        assertThat(remaining.size()).isEqualTo(1);
+        final PatternDescr cheese = (PatternDescr) remaining.get( 0 );
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement forall")
+    @Test
+    public void parse_ForallWithFrom() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "forallwithfrom.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final ForallDescr forall = (ForallDescr) rule.getLhs().getDescrs().get( 0 );
+
+        assertThat(forall.getDescrs().size()).isEqualTo(2);
+        final PatternDescr pattern = forall.getBasePattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        assertThat(((FromDescr) pattern.getSource()).getDataSource().toString()).isEqualTo("$village");
+        final List<BaseDescr> remaining = forall.getRemainingPatterns();
+        assertThat(remaining.size()).isEqualTo(1);
+        final PatternDescr cheese = (PatternDescr) remaining.get( 0 );
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+        assertThat(((FromDescr) cheese.getSource()).getDataSource().toString()).isEqualTo("$cheesery");
+    }
+
+    @Disabled("Priority : High | Implement memberOf")
+    @Test
+    public void parse_Memberof() throws Exception {
+        final String text = "rule X when Country( $cities : city )\nPerson( city memberOf $cities )\n then end";
+        AndDescr descrs = parseAndGetFirstRuleDescr(
+                                              text).getLhs();
+
+        assertThat(descrs.getDescrs().size()).isEqualTo(2);
+        PatternDescr pat = (PatternDescr) descrs.getDescrs().get( 1 );
+        ExprConstraintDescr fieldConstr = (ExprConstraintDescr) pat.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fieldConstr.getExpression()).isEqualTo("city memberOf $cities");
+    }
+
+    @Disabled("Priority : High | Implement not memberOf")
+    @Test
+    public void parse_NotMemberof() throws Exception {
+        final String text = "rule X when Country( $cities : city )\nPerson( city not memberOf $cities ) then end\n";
+        AndDescr descrs = parseAndGetFirstRuleDescr(
+                                              text).getLhs();
+
+        assertThat(descrs.getDescrs().size()).isEqualTo(2);
+        PatternDescr pat = (PatternDescr) descrs.getDescrs().get( 1 );
+        ExprConstraintDescr fieldConstr = (ExprConstraintDescr) pat.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fieldConstr.getExpression()).isEqualTo("city not memberOf $cities");
+    }
+
+    @Test
+    public void parse_InOperator() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "in_operator_test.drl" );
+
+        assertThat(rule).isNotNull();
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "consequence();");
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+
+        // The first pattern, with 2 restrictions on a single field (plus a
+        // connective)
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        ExprConstraintDescr fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(fld.getExpression()).isEqualTo("age > 30 && < 40");
+
+        // the second col, with 2 fields, the first with 2 restrictions, the
+        // second field with one
+        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("Vehicle");
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(2);
+
+        fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("type in ( \"sedan\", \"wagon\" )");
+
+        // now the second field
+        fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 1 );
+        assertThat(fld.getExpression()).isEqualTo("age < 3");
+
+    }
+
+    @Test
+    public void parse_NotInOperator() throws Exception {
+        final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
+                                                          "notin_operator_test.drl" );
+
+        assertThat(rule).isNotNull();
+
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "consequence();");
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+
+        // The first pattern, with 2 restrictions on a single field (plus a
+        // connective)
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        ExprConstraintDescr fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(fld.getExpression()).isEqualTo("age > 30 && < 40");
+
+        // the second col, with 2 fields, the first with 2 restrictions, the
+        // second field with one
+        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("Vehicle");
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(2);
+
+        fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("type not in ( \"sedan\", \"wagon\" )");
+
+        // now the second field
+        fld = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 1 );
+        assertThat(fld.getExpression()).isEqualTo("age < 3");
+
+    }
+
+    @Test
+    public void parse_CheckOrDescr() throws Exception {
+        final String text = "rule X when Person( eval( age == 25 ) || ( eval( name.equals( \"bob\" ) ) && eval( age == 30 ) ) ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        assertThat(AndDescr.class).isEqualTo(pattern.getConstraint().getClass());
+
+        assertThat(pattern.getConstraint().getDescrs().get(0).getClass()).isEqualTo(ExprConstraintDescr.class);
+
+    }
+
+    @Test
+    public void parse_ConstraintAndConnective() throws Exception {
+        final String text = "rule X when Person( age < 42 && location==\"atlanta\") then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualToIgnoringWhitespace("age < 42 && location==\"atlanta\"");
+    }
+
+    @Test
+    public void parse_ConstraintOrConnective() throws Exception {
+        final String text = "rule X when Person( age < 42 || location==\"atlanta\") then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualToIgnoringWhitespace("age < 42 || location==\"atlanta\"");
+    }
+
+    @Test
+    public void parse_Restrictions() throws Exception {
+        final String text = "rule X when Foo( bar > 1 || == 1 ) then end\n";
+
+        AndDescr descrs = (AndDescr) parseAndGetFirstRuleDescr(
+                                                         text ).getLhs();
+
+        assertThat(descrs.getDescrs().size()).isEqualTo(1);
+        PatternDescr pat = (PatternDescr) descrs.getDescrs().get( 0 );
+        ExprConstraintDescr fieldConstr = (ExprConstraintDescr) pat.getConstraint().getDescrs().get( 0 );
+
+        assertThat(fieldConstr.getExpression()).isEqualTo("bar > 1 || == 1");
+    }
+
+    @Disabled("Priority : High | Implement semicolon delimiter")
+    @Test
+    public void parse_Semicolon() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "semicolon.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(pkg.getName()).isEqualTo("org.drools.mvel.compiler");
+        assertThat(pkg.getGlobals().size()).isEqualTo(1);
+        assertThat(pkg.getRules().size()).isEqualTo(3);
+
+        final RuleDescr rule1 = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule1.getLhs().getDescrs().size()).isEqualTo(2);
+
+        final RuleDescr query1 = (RuleDescr) pkg.getRules().get( 1 );
+        assertThat(query1.getLhs().getDescrs().size()).isEqualTo(3);
+
+        final RuleDescr rule2 = (RuleDescr) pkg.getRules().get( 2 );
+        assertThat(rule2.getLhs().getDescrs().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void parse_Eval() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "eval_parsing.drl" );
+
+        assertThat(pkg.getName()).isEqualTo("org.drools.mvel.compiler");
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        final RuleDescr rule1 = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule1.getLhs().getDescrs().size()).isEqualTo(1);
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateReverse() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulateReverse.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.getInitCode()).isEqualToIgnoringWhitespace( "int x = 0 ;"
+                                       );
+        assertThat(accum.getActionCode()).isEqualToIgnoringWhitespace( "x++;"
+                                       );
+        assertThat(accum.getReverseCode()).isEqualToIgnoringWhitespace( "x--;"
+                                       );
+        assertThat(accum.getResultCode()).isEqualToIgnoringWhitespace( "new Integer(x)"
+                                       );
+        assertThat(accum.isExternalFunction()).isFalse();
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateExternalFunction() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulateExternalFunction.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.getFunctions().get( 0 ).getParams()[0]).isEqualToIgnoringWhitespace( "$age"
+                                       );
+        assertThat(accum.getFunctions().get( 0 ).getFunction()).isEqualToIgnoringWhitespace( "average"
+                                       );
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+    }
+
+    @Disabled("Priority : High | Implement from collect")
+    @Test
+    public void parse_CollectWithNestedFrom() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "collect_with_nested_from.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final CollectDescr collect = (CollectDescr) out.getSource();
+
+        PatternDescr person = (PatternDescr) collect.getInputPattern();
+        assertThat(person.getObjectType()).isEqualTo("Person");
+
+        final CollectDescr collect2 = (CollectDescr) person.getSource();
+
+        final PatternDescr people = collect2.getInputPattern();
+        assertThat(people.getObjectType()).isEqualTo("People");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateWithNestedFrom() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulate_with_nested_from.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accumulate = (AccumulateDescr) out.getSource();
+
+        PatternDescr person = (PatternDescr) accumulate.getInputPattern();
+        assertThat(person.getObjectType()).isEqualTo("Person");
+
+        final CollectDescr collect2 = (CollectDescr) person.getSource();
+
+        final PatternDescr people = collect2.getInputPattern();
+        assertThat(people.getObjectType()).isEqualTo("People");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateMultipleFunctions() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulateMultipleFunctions.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(out.getObjectType()).isEqualTo("Object");
+        AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        List<AccumulateDescr.AccumulateFunctionCallDescr> functions = accum.getFunctions();
+        assertThat(functions.size()).isEqualTo(3);
+        assertThat(functions.get(0).getFunction()).isEqualTo("average");
+        assertThat(functions.get(0).getBind()).isEqualTo("$a1");
+        assertThat(functions.get(0).getParams()[0]).isEqualTo("$price");
+
+        assertThat(functions.get(1).getFunction()).isEqualTo("min");
+        assertThat(functions.get(1).getBind()).isEqualTo("$m1");
+        assertThat(functions.get(1).getParams()[0]).isEqualTo("$price");
+
+        assertThat(functions.get(2).getFunction()).isEqualTo("max");
+        assertThat(functions.get(2).getBind()).isEqualTo("$M1");
+        assertThat(functions.get(2).getParams()[0]).isEqualTo("$price");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateMnemonic() throws Exception {
+        String drl = "package org.drools.mvel.compiler\n" +
+                "rule \"Accumulate 1\"\n" +
+                "when\n" +
+                "     acc( Cheese( $price : price ),\n" +
+                "          $a1 : average( $price ) )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr pkg = parser.parse(
+                                                       drl );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(out.getObjectType()).isEqualTo("Object");
+        AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        List<AccumulateDescr.AccumulateFunctionCallDescr> functions = accum.getFunctions();
+        assertThat(functions.size()).isEqualTo(1);
+        assertThat(functions.get(0).getFunction()).isEqualTo("average");
+        assertThat(functions.get(0).getBind()).isEqualTo("$a1");
+        assertThat(functions.get(0).getParams()[0]).isEqualTo("$price");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateMnemonic2() throws Exception {
+        String drl = "package org.drools.mvel.compiler\n" +
+                "rule \"Accumulate 1\"\n" +
+                "when\n" +
+                "     Number() from acc( Cheese( $price : price ),\n" +
+                "                        average( $price ) )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr pkg = parser.parse(
+                                                       drl );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(out.getObjectType()).isEqualTo("Number");
+        AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        List<AccumulateDescr.AccumulateFunctionCallDescr> functions = accum.getFunctions();
+        assertThat(functions.size()).isEqualTo(1);
+        assertThat(functions.get(0).getFunction()).isEqualTo("average");
+        assertThat(functions.get(0).getParams()[0]).isEqualTo("$price");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement import accumulate")
+    @Test
+    public void parse_ImportAccumulate() throws Exception {
+        String drl = "package org.drools.mvel.compiler\n" +
+                "import acc foo.Bar baz\n" +
+                "import accumulate foo.Bar2 baz2\n" +
+                "rule \"Accumulate 1\"\n" +
+                "when\n" +
+                "     acc( Cheese( $price : price ),\n" +
+                "          $v1 : baz( $price ), \n" +
+                "          $v2 : baz2( $price ) )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr pkg = parser.parse(
+                                                       drl );
+
+        assertThat(pkg.getAccumulateImports().size()).isEqualTo(2);
+        AccumulateImportDescr imp = (AccumulateImportDescr) pkg.getAccumulateImports().get(0);
+        assertThat(imp.getTarget()).isEqualTo("foo.Bar");
+        assertThat(imp.getFunctionName()).isEqualTo("baz");
+
+        imp = (AccumulateImportDescr) pkg.getAccumulateImports().get(1);
+        assertThat(imp.getTarget()).isEqualTo("foo.Bar2");
+        assertThat(imp.getFunctionName()).isEqualTo("baz2");
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(out.getObjectType()).isEqualTo("Object");
+        AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        List<AccumulateDescr.AccumulateFunctionCallDescr> functions = accum.getFunctions();
+        assertThat(functions.size()).isEqualTo(2);
+        assertThat(functions.get(0).getFunction()).isEqualTo("baz");
+        assertThat(functions.get(0).getBind()).isEqualTo("$v1");
+        assertThat(functions.get(0).getParams()[0]).isEqualTo("$price");
+
+        assertThat(functions.get(1).getFunction()).isEqualTo("baz2");
+        assertThat(functions.get(1).getBind()).isEqualTo("$v2");
+        assertThat(functions.get(1).getParams()[0]).isEqualTo("$price");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateMultipleFunctionsConstraint() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulateMultipleFunctionsConstraint.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(out.getObjectType()).isEqualTo("Object");
+        assertThat(out.getConstraint().getDescrs().size()).isEqualTo(2);
+        assertThat(out.getConstraint().getDescrs().get(0).toString()).isEqualTo("$a1 > 10 && $M1 <= 100");
+        assertThat(out.getConstraint().getDescrs().get(1).toString()).isEqualTo("$m1 == 5");
+        AccumulateDescr accum = (AccumulateDescr) out.getSource();
+        assertThat(accum.isExternalFunction()).isTrue();
+
+        List<AccumulateDescr.AccumulateFunctionCallDescr> functions = accum.getFunctions();
+        assertThat(functions.size()).isEqualTo(3);
+        assertThat(functions.get(0).getFunction()).isEqualTo("average");
+        assertThat(functions.get(0).getBind()).isEqualTo("$a1");
+        assertThat(functions.get(0).getParams()[0]).isEqualTo("$price");
+
+        assertThat(functions.get(1).getFunction()).isEqualTo("min");
+        assertThat(functions.get(1).getBind()).isEqualTo("$m1");
+        assertThat(functions.get(1).getParams()[0]).isEqualTo("$price");
+
+        assertThat(functions.get(2).getFunction()).isEqualTo("max");
+        assertThat(functions.get(2).getBind()).isEqualTo("$M1");
+        assertThat(functions.get(2).getParams()[0]).isEqualTo("$price");
+
+        final PatternDescr pattern = (PatternDescr) accum.getInputPattern();
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Test
+    public void parse_OrCE() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "or_ce.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
+
+        final PatternDescr person = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(person.getObjectType()).isEqualTo("Person");
+        assertThat(person.getIdentifier()).isEqualTo("$p");
+
+        final OrDescr or = (OrDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+
+        final PatternDescr cheese1 = (PatternDescr) or.getDescrs().get( 0 );
+        assertThat(cheese1.getObjectType()).isEqualTo("Cheese");
+        assertThat(cheese1.getIdentifier()).isEqualTo("$c");
+        final PatternDescr cheese2 = (PatternDescr) or.getDescrs().get( 1 );
+        assertThat(cheese2.getObjectType()).isEqualTo("Cheese");
+        assertThat(cheese2.getIdentifier()).isNull();
+    }
+
+    @Test
+    public void parse_RuleSingleLine() throws Exception {
+        final String text = "rule \"another test\" salience 10 when eval( true ) then System.out.println(1); end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(
+                                            text );
+
+        assertThat(rule.getName()).isEqualTo("another test");
+        assertThat((String)rule.getConsequence()).isEqualToIgnoringWhitespace("System.out.println(1); ");
+    }
+
+    @Test
+    public void parse_RuleTwoLines() throws Exception {
+        final String text = "rule \"another test\" salience 10 when eval( true ) then System.out.println(1);\n end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(
+                                            text );
+
+        assertThat(rule.getName()).isEqualTo("another test");
+        assertThat((String)rule.getConsequence()).isEqualToIgnoringWhitespace("System.out.println(1);\n ");
+    }
+
+    @Test
+    public void parse_RuleParseLhs3() throws Exception {
+        final String text = "rule X when (or\nnot Person()\n(and Cheese()\nMeat()\nWine())) then end";
+        AndDescr pattern = parseAndGetFirstRuleDescr(
+                                               text ).getLhs();
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        OrDescr or = (OrDescr) pattern.getDescrs().get( 0 );
+        assertThat(or.getDescrs().size()).isEqualTo(2);
+        NotDescr not = (NotDescr) or.getDescrs().get( 0 );
+        AndDescr and = (AndDescr) or.getDescrs().get( 1 );
+        assertThat(not.getDescrs().size()).isEqualTo(1);
+        PatternDescr person = (PatternDescr) not.getDescrs().get( 0 );
+        assertThat(person.getObjectType()).isEqualTo("Person");
+        assertThat(and.getDescrs().size()).isEqualTo(3);
+        PatternDescr cheese = (PatternDescr) and.getDescrs().get( 0 );
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+        PatternDescr meat = (PatternDescr) and.getDescrs().get( 1 );
+        assertThat(meat.getObjectType()).isEqualTo("Meat");
+        PatternDescr wine = (PatternDescr) and.getDescrs().get( 2 );
+        assertThat(wine.getObjectType()).isEqualTo("Wine");
+
+    }
+
+    @Disabled("Priority : High | Implement accumulate")
+    @Test
+    public void parse_AccumulateMultiPattern() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "accumulate_multi_pattern.drl" );
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+
+        final PatternDescr outPattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        final AccumulateDescr accum = (AccumulateDescr) outPattern.getSource();
+        assertThat(outPattern.getIdentifier()).isEqualToIgnoringWhitespace( "$counter"
+                                       );
+        assertThat(accum.getInitCode()).isEqualToIgnoringWhitespace( "int x = 0 ;"
+                                       );
+        assertThat(accum.getActionCode()).isEqualToIgnoringWhitespace( "x++;"
+                                      );
+        assertThat(accum.getResultCode()).isEqualToIgnoringWhitespace( "new Integer(x)"
+                                       );
+
+        final AndDescr and = (AndDescr) accum.getInput();
+        assertThat(and.getDescrs().size()).isEqualTo(2);
+        final PatternDescr person = (PatternDescr) and.getDescrs().get( 0 );
+        final PatternDescr cheese = (PatternDescr) and.getDescrs().get( 1 );
+        assertThat(person.getObjectType()).isEqualTo("Person");
+        assertThat(cheese.getObjectType()).isEqualTo("Cheese");
+    }
+
+    @Disabled("Priority : High | Implement temporal operators")
+    @Test
+    public void parse_PluggableOperators() throws Exception {
+
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "pluggable_operators.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(5);
+
+        final PatternDescr eventA = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(eventA.getIdentifier()).isEqualTo("$a");
+        assertThat(eventA.getObjectType()).isEqualTo("EventA");
+
+        final PatternDescr eventB = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(eventB.getIdentifier()).isEqualTo("$b");
+        assertThat(eventB.getObjectType()).isEqualTo("EventB");
+        assertThat(eventB.getConstraint().getDescrs().size()).isEqualTo(1);
+        assertThat(eventB.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        final ExprConstraintDescr fcdB = (ExprConstraintDescr) eventB.getConstraint().getDescrs().get( 0 );
+        assertThat(fcdB.getExpression()).isEqualTo("this after[1,10] $a || this not after[15,20] $a");
+
+        final PatternDescr eventC = (PatternDescr) rule.getLhs().getDescrs().get( 2 );
+        assertThat(eventC.getIdentifier()).isEqualTo("$c");
+        assertThat(eventC.getObjectType()).isEqualTo("EventC");
+        assertThat(eventC.getConstraint().getDescrs().size()).isEqualTo(1);
+        final ExprConstraintDescr fcdC = (ExprConstraintDescr) eventC.getConstraint().getDescrs().get( 0 );
+        assertThat(fcdC.getExpression()).isEqualTo("this finishes $b");
+
+        final PatternDescr eventD = (PatternDescr) rule.getLhs().getDescrs().get( 3 );
+        assertThat(eventD.getIdentifier()).isEqualTo("$d");
+        assertThat(eventD.getObjectType()).isEqualTo("EventD");
+        assertThat(eventD.getConstraint().getDescrs().size()).isEqualTo(1);
+        final ExprConstraintDescr fcdD = (ExprConstraintDescr) eventD.getConstraint().getDescrs().get( 0 );
+        assertThat(fcdD.getExpression()).isEqualTo("this not starts $a");
+
+        final PatternDescr eventE = (PatternDescr) rule.getLhs().getDescrs().get( 4 );
+        assertThat(eventE.getIdentifier()).isEqualTo("$e");
+        assertThat(eventE.getObjectType()).isEqualTo("EventE");
+        assertThat(eventE.getConstraint().getDescrs().size()).isEqualTo(1);
+
+        ExprConstraintDescr fcdE = (ExprConstraintDescr) eventE.getConstraint().getDescrs().get( 0 );
+        assertThat(fcdE.getExpression()).isEqualTo("this not before[1, 10] $b || after[1, 10] $c && this after[1, 5] $d");
+    }
+
+    @Test
+    public void parse_RuleMetadata() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "Rule_with_Metadata.drl" );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        // @fooAttribute(barValue)
+        // @fooAtt2(barVal2)
+        RuleDescr rule = pkg.getRules().get( 0 );
+        assertThat(rule.getAnnotationNames().contains("fooMeta1")).isTrue();
+        assertThat(rule.getAnnotation("fooMeta1").getValue()).isEqualTo("barVal1");
+        assertThat(rule.getAnnotationNames().contains("fooMeta2")).isTrue();
+        assertThat(rule.getAnnotation("fooMeta2").getValue()).isEqualTo("barVal2");
+        assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace( "System.out.println(\"Consequence\");"
+                                      );
+    }
+
+    @Disabled("Priority : High | Implement extends")
+    @Test
+    public void parse_RuleExtends() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "Rule_with_Extends.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        RuleDescr rule = pkg.getRules().get( 0 );
+        assertThat(rule.getParentName() != null).isTrue();
+        assertThat(rule.getParentName()).isEqualTo("rule1");
+
+        AndDescr lhs = rule.getLhs();
+        assertThat(lhs).isNotNull();
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+
+        PatternDescr pattern = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("foo");
+        assertThat(pattern.getIdentifier()).isEqualTo("$foo");
+
+    }
+
+    @Disabled("Priority : High | Implement type declaration")
+    @Test
+    public void parse_TypeDeclarationWithFields() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "declare_type_with_fields.drl" );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        List<TypeDeclarationDescr> td = pkg.getTypeDeclarations();
+        assertThat(td.size()).isEqualTo(3);
+
+        TypeDeclarationDescr d = td.get( 0 );
+        assertThat(d.getTypeName()).isEqualTo("SomeFact");
+        assertThat(d.getFields().size()).isEqualTo(2);
+        assertThat(d.getFields().containsKey("name")).isTrue();
+        assertThat(d.getFields().containsKey("age")).isTrue();
+
+        TypeFieldDescr f = d.getFields().get("name" );
+        assertThat(f.getPattern().getObjectType()).isEqualTo("String");
+
+        f = d.getFields().get( "age" );
+        assertThat(f.getPattern().getObjectType()).isEqualTo("Integer");
+
+        d = td.get( 1 );
+        assertThat(d.getTypeName()).isEqualTo("AnotherFact");
+
+        TypeDeclarationDescr type = td.get( 2 );
+        assertThat(type.getTypeName()).isEqualTo("Person");
+
+        assertThat(type.getAnnotation("role").getValue()).isEqualTo("fact");
+        assertThat(type.getAnnotation("doc").getValue("descr")).isEqualTo("\"Models a person\"");
+        assertThat(type.getAnnotation("doc").getValue("author")).isEqualTo("\"Bob\"");
+        assertThat(type.getAnnotation("doc").getValue("date")).isEqualTo("Calendar.getInstance().getDate()");
+
+        assertThat(type.getFields().size()).isEqualTo(2);
+        TypeFieldDescr field = type.getFields().get( "name" );
+        assertThat(field.getFieldName()).isEqualTo("name");
+        assertThat(field.getPattern().getObjectType()).isEqualTo("String");
+        assertThat(field.getInitExpr()).isEqualTo("\"John Doe\"");
+        assertThat(field.getAnnotation("length").getValue("max")).isEqualTo("50");
+        assertThat( field.getAnnotation( "key" ) ).isNotNull();
+
+        field = type.getFields().get( "age" );
+        assertThat(field.getFieldName()).isEqualTo("age");
+        assertThat(field.getPattern().getObjectType()).isEqualTo("int");
+        assertThat(field.getInitExpr()).isEqualTo("-1");
+        assertThat(field.getAnnotation("ranged").getValue("min")).isEqualTo("0");
+        assertThat(field.getAnnotation("ranged").getValue("max")).isEqualTo("150");
+        assertThat(field.getAnnotation("ranged").getValue("unknown")).isEqualTo("-1");
+
+    }
+
+    @Disabled("Priority : High | Failed to parse or with parentheses in LHS")
+    @Test
+    public void parse_RuleWithLHSNesting() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "Rule_with_nested_LHS.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        RuleDescr rule = pkg.getRules().get( 0 );
+        assertThat(rule.getName()).isEqualTo("test");
+
+        AndDescr lhs = rule.getLhs();
+        assertThat(lhs).isNotNull();
+        assertThat(lhs.getDescrs().size()).isEqualTo(2);
+
+        PatternDescr a = (PatternDescr) lhs.getDescrs().get( 0 );
+        assertThat(a.getObjectType()).isEqualTo("A");
+
+        OrDescr or = (OrDescr) lhs.getDescrs().get( 1 );
+        assertThat(or.getDescrs().size()).isEqualTo(3);
+
+        AndDescr and1 = (AndDescr) or.getDescrs().get( 0 );
+        assertThat(and1.getDescrs().size()).isEqualTo(2);
+        PatternDescr b = (PatternDescr) and1.getDescrs().get( 0 );
+        PatternDescr c = (PatternDescr) and1.getDescrs().get( 1 );
+        assertThat(b.getObjectType()).isEqualTo("B");
+        assertThat(c.getObjectType()).isEqualTo("C");
+
+        AndDescr and2 = (AndDescr) or.getDescrs().get( 1 );
+        assertThat(and2.getDescrs().size()).isEqualTo(2);
+        PatternDescr d = (PatternDescr) and2.getDescrs().get( 0 );
+        PatternDescr e = (PatternDescr) and2.getDescrs().get( 1 );
+        assertThat(d.getObjectType()).isEqualTo("D");
+        assertThat(e.getObjectType()).isEqualTo("E");
+
+        AndDescr and3 = (AndDescr) or.getDescrs().get( 2 );
+        assertThat(and3.getDescrs().size()).isEqualTo(2);
+        PatternDescr f = (PatternDescr) and3.getDescrs().get( 0 );
+        PatternDescr g = (PatternDescr) and3.getDescrs().get( 1 );
+        assertThat(f.getObjectType()).isEqualTo("F");
+        assertThat(g.getObjectType()).isEqualTo("G");
+    }
+
+    @Disabled("Priority : High | Implement from entry-point")
+    @Test
+    public void parse_EntryPoint() throws Exception {
+        final String text = "rule X when StockTick( symbol==\"ACME\") from entry-point StreamA then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 text );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        RuleDescr rule = pkg.getRules().get( 0 );
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("symbol==\"ACME\"");
+
+        assertThat(pattern.getSource()).isNotNull();
+        EntryPointDescr entry = (EntryPointDescr) pattern.getSource();
+        assertThat(entry.getEntryId()).isEqualTo("StreamA");
+    }
+
+    @Disabled("Priority : High | Implement from entry-point")
+    @Test
+    public void parse_EntryPoint2() throws Exception {
+        final String text = "rule X when StockTick( symbol==\"ACME\") from entry-point \"StreamA\" then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 text );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        RuleDescr rule = pkg.getRules().get( 0 );
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("symbol==\"ACME\"");
+
+        assertThat(pattern.getSource()).isNotNull();
+        EntryPointDescr entry = (EntryPointDescr) pattern.getSource();
+        assertThat(entry.getEntryId()).isEqualTo("StreamA");
+    }
+
+    @Disabled("Priority : High | Implement sliding window")
+    @Test
+    public void parse_SlidingWindow() throws Exception {
+        final String text = "rule X when StockTick( symbol==\"ACME\") over window:length(10) then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 text );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        RuleDescr rule = pkg.getRules().get( 0 );
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("symbol==\"ACME\"");
+
+        List<BehaviorDescr> behaviors = pattern.getBehaviors();
+        assertThat(behaviors).isNotNull();
+        assertThat(behaviors.size()).isEqualTo(1);
+        BehaviorDescr descr = behaviors.get( 0 );
+        assertThat(descr.getType()).isEqualTo("window");
+        assertThat(descr.getSubType()).isEqualTo("length");
+        assertThat(descr.getParameters().get(0)).isEqualTo("10");
+    }
+
+    @Disabled("Priority : Mid | outmost parentheses")
+    @Test
+    public void parse_RuleOldSyntax1() throws Exception {
+        final String source = "rule \"Test\" when ( not $r :LiteralRestriction( operator == Operator.EQUAL ) ) then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 source );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        assertThat(rule.getName()).isEqualTo("Test");
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        assertThat(((NotDescr) rule.getLhs().getDescrs().get(0)).getDescrs().size()).isEqualTo(1);
+        NotDescr notDescr = (NotDescr) rule.getLhs().getDescrs().get( 0 );
+        PatternDescr patternDescr = (PatternDescr) notDescr.getDescrs().get( 0 );
+        assertThat(patternDescr.getIdentifier()).isEqualTo("$r");
+        assertThat(patternDescr.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fieldConstraintDescr = (ExprConstraintDescr) patternDescr.getDescrs().get( 0 );
+        assertThat(fieldConstraintDescr.getExpression()).isEqualToIgnoringWhitespace("operator == Operator.EQUAL");
+    }
+
+    @Disabled("Priority : Mid | outmost parentheses")
+    @Test
+    public void parse_RuleOldSyntax2() throws Exception {
+        final String source = "rule \"Test\" when ( $r :LiteralRestriction( operator == Operator.EQUAL ) ) then end";
+
+        PackageDescr pkg = parser.parse(
+                                                 source );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+
+        assertThat(rule.getName()).isEqualTo("Test");
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        PatternDescr patternDescr = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(patternDescr.getIdentifier()).isEqualTo("$r");
+        assertThat(patternDescr.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fieldConstraintDescr = (ExprConstraintDescr) patternDescr.getDescrs().get( 0 );
+        assertThat(fieldConstraintDescr.getExpression()).isEqualToIgnoringWhitespace("operator == Operator.EQUAL");
+    }
+
+    @Disabled("Priority : High | Implement type declaration")
+    @Test
+    public void parse_TypeWithMetaData() throws Exception {
+
+        PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                         "type_with_meta.drl" );
+
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        final List<TypeDeclarationDescr> declarations = pkg.getTypeDeclarations();
+
+        assertThat(declarations.size()).isEqualTo(3);
+    }
+
+    @Disabled("Priority : Mid | Implement Descr position")
+    @Test
+    public void parse_NullConstraints() throws Exception {
+        final String text = "rule X when Person( name == null ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(1);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("name == null");
+        assertThat(fcd.getPosition()).isEqualTo(0);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
+    }
+
+    @Disabled("Priority : High | Implement positional constraint")
+    @Test
+    public void parse_PositionalConstraintsOnly() throws Exception {
+        final String text = "rule X when Person( \"Mark\", 42; ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(2);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("\"Mark\"");
+        assertThat(fcd.getPosition()).isEqualTo(0);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+        fcd = (ExprConstraintDescr) pattern.getDescrs().get( 1 );
+        assertThat(fcd.getExpression()).isEqualTo("42");
+        assertThat(fcd.getPosition()).isEqualTo(1);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+    }
+
+    @Disabled("Priority : High | Implement query")
+    @Test
+    public void parse_IsQuery() throws Exception {
+        final String text = "rule X when ?person( \"Mark\", 42; ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.isQuery()).isTrue();
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(2);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("\"Mark\"");
+        assertThat(fcd.getPosition()).isEqualTo(0);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+        fcd = (ExprConstraintDescr) pattern.getDescrs().get( 1 );
+        assertThat(fcd.getExpression()).isEqualTo("42");
+        assertThat(fcd.getPosition()).isEqualTo(1);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+    }
+
+    @Disabled("Priority : Mid | Implement query with from")
+    @Test
+    public void parse_FromFollowedByQuery() throws Exception {
+        // the 'from' expression requires a ";" to disambiguate the "?" 
+        // prefix for queries from the ternary operator "? :"
+        final String text = "rule X when Cheese() from $cheesery ?person( \"Mark\", 42; ) then end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(
+                                            text );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+        assertThat(pattern.getSource().getText()).isEqualTo("from $cheesery");
+        assertThat(pattern.isQuery()).isFalse();
+
+        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("person");
+        assertThat(pattern.isQuery()).isTrue();
+
+    }
+
+    @Disabled("Priority : Mid | Implement query with from")
+    @Test
+    public void parse_FromWithTernaryFollowedByQuery() throws Exception {
+        // the 'from' expression requires a ";" to disambiguate the "?" 
+        // prefix for queries from the ternary operator "? :"
+        final String text = "rule X when Cheese() from (isFull ? $cheesery : $market) ?person( \"Mark\", 42; ) then end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(
+                                            text );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(pattern.getObjectType()).isEqualTo("Cheese");
+        assertThat(pattern.getSource().getText()).isEqualToIgnoringWhitespace("from (isFull ? $cheesery : $market)");
+        assertThat(pattern.isQuery()).isFalse();
+
+        pattern = (PatternDescr) rule.getLhs().getDescrs().get( 1 );
+        assertThat(pattern.getObjectType()).isEqualTo("person");
+        assertThat(pattern.isQuery()).isTrue();
+
+    }
+
+    @Disabled("Priority : Low | Implement multi-value annotation. Not written in docs")
+    @Test
+    public void parse_MultiValueAnnotationsBackwardCompatibility() throws Exception {
+        // multiple values with no keys are parsed as a single value
+        final String text = "rule X @ann1( val1, val2 ) @ann2( \"val1\", \"val2\" ) when then end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(
+                                            text );
+
+        AnnotationDescr ann = rule.getAnnotation("ann1" );
+        assertThat(ann).isNotNull();
+        assertThat(ann.getValue()).isEqualTo("val1, val2");
+
+        ann = rule.getAnnotation( "ann2" );
+        assertThat(ann).isNotNull();
+        assertThat(ann.getValue()).isEqualTo("\"val1\", \"val2\"");
+    }
+
+    @Disabled("Priority : High | Implement positional constraint")
+    @Test
+    public void parse_PositionalsAndNamedConstraints() throws Exception {
+        final String text = "rule X when Person( \"Mark\", 42; location == \"atlanta\" ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(3);
+        ExprConstraintDescr fcd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(fcd.getExpression()).isEqualTo("\"Mark\"");
+        assertThat(fcd.getPosition()).isEqualTo(0);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+        fcd = (ExprConstraintDescr) pattern.getDescrs().get( 1 );
+        assertThat(fcd.getExpression()).isEqualTo("42");
+        assertThat(fcd.getPosition()).isEqualTo(1);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
+
+        fcd = (ExprConstraintDescr) pattern.getDescrs().get( 2 );
+        assertThat(fcd.getExpression()).isEqualTo("location == \"atlanta\"");
+        assertThat(fcd.getPosition()).isEqualTo(2);
+        assertThat(fcd.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
+
+    }
+
+    @Disabled("Priority : High | Implement unification")
+    @Test
+    public void parse_UnificationBinding() throws Exception {
+        final String text = "rule X when $p := Person( $name := name, $loc : location ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getIdentifier()).isEqualTo("$p");
+        assertThat(pattern.isUnification()).isTrue();
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(2);
+        ExprConstraintDescr bindingDescr = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(bindingDescr.getExpression()).isEqualTo("$name := name");
+
+        bindingDescr = (ExprConstraintDescr) pattern.getDescrs().get( 1 );
+        assertThat(bindingDescr.getExpression()).isEqualTo("$loc : location");
+
+    }
+
+    @Disabled("Priority : High | Implement BigInteger literal, BigDecimal literal")
+    @Test
+    public void parse_BigLiterals() throws Exception {
+        final String text = "rule X when Primitives( bigInteger == (10I), " +
+                "                        bigDecimal == (10B), " +
+                "                        bigInteger < 50I, " +
+                "                        bigDecimal < 50B ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getDescrs().size()).isEqualTo(4);
+        ExprConstraintDescr ecd = (ExprConstraintDescr) pattern.getDescrs().get( 0 );
+        assertThat(ecd.getExpression()).isEqualTo("bigInteger == (10I)");
+
+        ecd = (ExprConstraintDescr) pattern.getDescrs().get( 1 );
+        assertThat(ecd.getExpression()).isEqualTo("bigDecimal == (10B)");
+
+        ecd = (ExprConstraintDescr) pattern.getDescrs().get( 2 );
+        assertThat(ecd.getExpression()).isEqualTo("bigInteger < 50I");
+
+        ecd = (ExprConstraintDescr) pattern.getDescrs().get( 3 );
+        assertThat(ecd.getExpression()).isEqualTo("bigDecimal < 50B");
+    }
+
+    @Disabled("Priority : High | Failed to parse binding with ||")
+    @Test
+    public void parse_BindingComposite() throws Exception {
+        final String text = "rule X when Person( $name : name == \"Bob\" || $loc : location == \"Montreal\" ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        assertThat(pattern.isUnification()).isFalse();
+
+        // embedded bindings are extracted at compile time
+        List< ? > constraints = pattern.getDescrs();
+        assertThat(constraints.size()).isEqualTo(1);
+        assertThat(((ExprConstraintDescr) constraints.get(0)).getExpression()).isEqualTo("$name : name == \"Bob\" || $loc : location == \"Montreal\"");
+    }
+
+    @Disabled("Priority : High | Failed to parse binding with ||")
+    @Test
+    public void parse_BindingCompositeWithMethods() throws Exception {
+        final String text = "rule X when Person( $name : name.toUpperCase() == \"Bob\" || $loc : location[0].city == \"Montreal\" ) then end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        assertThat(pattern.isUnification()).isFalse();
+
+        // embedded bindings are extracted at compile time
+        List< ? > constraints = pattern.getDescrs();
+        assertThat(constraints.size()).isEqualTo(1);
+        assertThat(((ExprConstraintDescr) constraints.get(0)).getExpression()).isEqualTo("$name : name.toUpperCase() == \"Bob\" || $loc : location[0].city == \"Montreal\"");
+    }
+
+    @Disabled("Priority : High | Implement temporal operators")
+    @Test
+    public void parse_PluggableOperators2() throws Exception {
+        final String text = "rule \"tt\"\n" +
+                "    dialect \"mvel\"\n" +
+                "when\n" +
+                "    exists (TelephoneCall( this finishes [1m] \"25-May-2011\" ))\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) ((ExistsDescr) parseAndGetFirstRuleDescr(
+                                                                                 text ).getLhs().getDescrs().get( 0 )).getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("TelephoneCall");
+        ExprConstraintDescr constr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(constr.getText()).isEqualTo("this finishes [1m] \"25-May-2011\"");
+
+    }
+
+    @Test
+    public void parse_InlineEval() throws Exception {
+        final String text = "rule \"inline eval\"\n" +
+                "when\n" +
+                "    Person( eval( name.startsWith(\"b\") && name.finishesWith(\"b\")) )\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("Person");
+        ExprConstraintDescr constr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(constr.getText()).isEqualToIgnoringWhitespace("eval( name.startsWith(\"b\") && name.finishesWith(\"b\"))");
+
+    }
+
+    @Disabled("Priority : High | Implement temporal operators")
+    @Test
+    public void parse_InfinityLiteral() throws Exception {
+        final String text = "rule \"infinity\"\n" +
+                "when\n" +
+                "    StockTick( this after[-*,*] $another )\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(
+                                                                  text ).getLhs().getDescrs().get( 0 );
+
+        assertThat(pattern.getObjectType()).isEqualTo("StockTick");
+        ExprConstraintDescr constr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get( 0 );
+        assertThat(constr.getText()).isEqualTo("this after[-*,*] $another");
+
+    }
+
+    @Disabled("Priority : High | Implement entry-point declaration")
+    @Test
+    public void parse_EntryPointDeclaration() throws Exception {
+        final String text = "package org.drools\n" +
+                "declare entry-point eventStream\n" +
+                "    @source(\"jndi://queues/events\")\n" +
+                "    @foo( true )\n" +
+                "end";
+        PackageDescr pkg = parser.parse(
+                                                 text );
+
+        assertThat(pkg.getName()).isEqualTo("org.drools");
+        assertThat(pkg.getEntryPointDeclarations().size()).isEqualTo(1);
+
+        EntryPointDeclarationDescr epd = pkg.getEntryPointDeclarations().iterator().next();
+
+        assertThat(epd.getEntryPointId()).isEqualTo("eventStream");
+        assertThat(epd.getAnnotations().size()).isEqualTo(2);
+        assertThat(epd.getAnnotation("source").getValue()).isEqualTo("\"jndi://queues/events\"");
+        assertThat(epd.getAnnotation("foo").getValue()).isEqualTo("true");
+    }
+
+    @Disabled("Priority : Mid | Implement sliding window declaration")
+    @Test
+    public void parse_WindowDeclaration() throws Exception {
+        final String text = "package org.drools\n" +
+                "declare window Ticks\n" +
+                "    @doc(\"last 10 stock ticks\")\n" +
+                "    $s : StockTick( source == \"NYSE\" )\n" +
+                "        over window:length( 10, $s.symbol )\n" +
+                "        from entry-point stStream\n" +
+                "end";
+        PackageDescr pkg = parser.parse(
+                                                 text );
+
+        assertThat(pkg.getName()).isEqualTo("org.drools");
+        assertThat(pkg.getWindowDeclarations().size()).isEqualTo(1);
+
+        WindowDeclarationDescr wdd = pkg.getWindowDeclarations().iterator().next();
+
+        assertThat(wdd.getName()).isEqualTo("Ticks");
+        assertThat(wdd.getAnnotations().size()).isEqualTo(1);
+        assertThat(wdd.getAnnotation("doc").getValue()).isEqualTo("\"last 10 stock ticks\"");
+
+        PatternDescr pd = wdd.getPattern();
+        assertThat(pd).isNotNull();
+        assertThat(pd.getIdentifier()).isEqualTo("$s");
+        assertThat(pd.getObjectType()).isEqualTo("StockTick");
+        assertThat(pd.getSource().getText()).isEqualTo("stStream");
+
+        assertThat(pd.getBehaviors().size()).isEqualTo(1);
+        BehaviorDescr bd = pd.getBehaviors().get( 0 );
+        assertThat(bd.getType()).isEqualTo("window");
+        assertThat(bd.getSubType()).isEqualTo("length");
+        assertThat(bd.getParameters().size()).isEqualTo(2);
+        assertThat(bd.getParameters().get(0)).isEqualTo("10");
+        assertThat(bd.getParameters().get(1)).isEqualTo("$s.symbol");
+    }
+
+    @Disabled("Priority : Mid | Implement using declared window. Not written in docs, but unit tests found.")
+    @Test
+    public void parse_WindowUsage() throws Exception {
+        final String text = "package org.drools\n" +
+                "rule X\n" +
+                "when\n" +
+                "    StockTick() from window Y\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr pkg = parser.parse(
+                                                 text );
+
+        assertThat(pkg.getName()).isEqualTo("org.drools");
+        assertThat(pkg.getRules().size()).isEqualTo(1);
+
+        RuleDescr rd = pkg.getRules().get(0);
+
+        assertThat(rd.getName()).isEqualTo("X");
+        assertThat(rd.getLhs().getDescrs().size()).isEqualTo(1);
+
+        PatternDescr pd = (PatternDescr) rd.getLhs().getDescrs().get(0);
+        assertThat(pd).isNotNull();
+        assertThat(pd.getObjectType()).isEqualTo("StockTick");
+        assertThat(pd.getSource().getText()).isEqualTo("Y");
+    }
+
 }

--- a/drools-parser/src/test/resources/org/drools/parser/Rule_with_Extends.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/Rule_with_Extends.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule test_rule extends rule1
+    when
+        $foo : foo()
+    then
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/Rule_with_Metadata.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/Rule_with_Metadata.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+package org.drools.compiler
+
+rule test_rule
+    @fooMeta1(barVal1)
+    @fooMeta2(barVal2)
+    when
+    then
+        System.out.println("Consequence");
+end

--- a/drools-parser/src/test/resources/org/drools/parser/Rule_with_nested_LHS.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/Rule_with_nested_LHS.drl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule test
+    when
+        A()
+        ( B() and C() ) or
+        ( D() and E() ) or
+        ( F() and G() )
+    then
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulate.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulate.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateParserTest"
+when
+     Integer() from accumulate( Person( age > 21 ),
+                                init( int x = 0; ),
+                                action( x++; ),
+                                result( new Integer(x) ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulateExternalFunction.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulateExternalFunction.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateReverseParserTest"
+when
+     Number() from accumulate( Person( $age : age > 21 ),
+                               average( $age ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulateMultipleFunctions.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulateMultipleFunctions.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule "Accumulate 1"
+when
+     accumulate( Cheese( $price : price ),
+                 $a1 : average( $price ),
+                 $m1 : min( $price ),
+                 $M1 : max( $price ) // binds are optional, but it makes no sense to not have a binding in this case
+        )
+then
+     // do something
+end
+

--- a/drools-parser/src/test/resources/org/drools/parser/accumulateMultipleFunctionsConstraint.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulateMultipleFunctionsConstraint.drl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule "Accumulate 1"
+when
+     accumulate( Cheese( $price : price );
+                 $a1 : average( $price ),
+                 $m1 : min( $price ),
+                 $M1 : max( $price ); // binds are optional, but it makes no sense to not have a binding in this case
+                 $a1 > 10 && $M1 <= 100,
+                 $m1 == 5 // inline evals
+        )
+then
+     // do something
+end
+

--- a/drools-parser/src/test/resources/org/drools/parser/accumulateReverse.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulateReverse.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateReverseParserTest"
+when
+     Integer() from accumulate( Person( age > 21 ),
+                                init( int x = 0; ),
+                                action( x++; ),
+                                reverse( x--; ),
+                                result( new Integer(x) ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulate_multi_pattern.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulate_multi_pattern.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateMultiPatternParserTest"
+when
+     $counter:Integer() from accumulate( $person : Person( age > 21 ) and Cheese( type == $person.likes ),
+                                         init( int x = 0; ),
+                                         action( x++; ),
+                                         result( new Integer(x) ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulate_with_bindings.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulate_with_bindings.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateParserTest"
+when
+     $counter:Integer() from accumulate( $person : Person( age > 21 ),
+                                         init( int x = 0; ),
+                                         action( x++; ),
+                                         result( new Integer(x) ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/accumulate_with_nested_from.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/accumulate_with_nested_from.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "AccumulateParserTest"
+when
+     // below statement makes no sense, but is useful to test parsing recursiveness
+     $personList : ArrayList() from accumulate( Person( $age : age > 21 || < 10 ) from collect( People() from $town.getPeople() ),
+                                                max( $age ) );
+then
+end
+

--- a/drools-parser/src/test/resources/org/drools/parser/and_or_rule.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/and_or_rule.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+import org.drools.compiler.Person
+
+rule simple_rule 
+  when
+    Person(name == "mark") and Cheese(type == "stilton")
+    Person(name == "mark") or Cheese(type == "stilton")
+  then
+    System.out.println( "Mark and Michael" );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/basic_binding.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/basic_binding.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+
+rule "like cheddar"
+    when
+        Cheese( $type:type )
+    then
+        System.out.println("I like " + $type);
+end    

--- a/drools-parser/src/test/resources/org/drools/parser/bindings.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/bindings.drl
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+import org.drools.compiler.Person;
+
+rule "Who likes Stilton"
+    when
+        Cheese($type : type == "stilton")
+        $person : Person( $name : name == "bob", likes == $type)        
+    then
+        System.out.println( $name + " likes " + $type);
+end    

--- a/drools-parser/src/test/resources/org/drools/parser/brackets_precedence.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/brackets_precedence.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+     ( (not Foo(x=="a") or Foo(x=="y") ) and ( Shoes() or Butt() ) )
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/collect.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/collect.drl
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "CollectParserTest"
+when
+     $personList : ArrayList() from collect( Person( age > 21 ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/collect_with_nested_from.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/collect_with_nested_from.drl
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "CollectParserTest"
+when
+     // below statement makes no sense, but is useful to test parsing recursiveness
+     $personList : ArrayList() from collect( $p : Person( age > 21 || age < 10 ) from collect( People() from $town.getPeople() ) );
+then
+end
+

--- a/drools-parser/src/test/resources/org/drools/parser/comment.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/comment.drl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+//this starts with a comment
+package foo.bar
+
+//and another comment
+
+/*
+yet
+       another
+                   style
+*/
+
+rule "test"
+  when
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/complex.dsl
+++ b/drools-parser/src/test/resources/org/drools/parser/complex.dsl
@@ -1,0 +1,5 @@
+#place your comments here - this is just a description for your own purposes.
+[when]There is a Person with name of {name}=Person(name=="{name}")
+[when]Person is at least {age} years old and lives in {location}=Person(age > {age}, location == "{location}")
+[then]Log "{message}"=System.out.println("{message}");
+[when]Or=or

--- a/drools-parser/src/test/resources/org/drools/parser/declare_type_with_fields.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/declare_type_with_fields.drl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare SomeFact
+    name : String
+    age: Integer
+end
+
+declare AnotherFact
+
+end
+
+declare Person
+    @role( fact )
+    @doc( descr="Models a person",
+          author="Bob",
+          date=Calendar.getInstance().getDate() )
+    
+    name   : String = "John Doe" @key @length( max = 50 )
+    age    : int    = -1         @ranged( min = 0, max = 150, unknown = -1 )
+end

--- a/drools-parser/src/test/resources/org/drools/parser/enumeration.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/enumeration.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+      Foo(bar == Foo.BAR)
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/escaped-string.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/escaped-string.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "test_Quotes"
+   when
+      InitialFact()
+   then
+      String s = "\"\n\t\\";
+end 

--- a/drools-parser/src/test/resources/org/drools/parser/eval_multiple.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/eval_multiple.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+    eval(abc("foo") + 5)
+    Foo()
+    eval(qed())
+    Bar()
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/eval_parsing.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/eval_parsing.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.mvel.compiler
+
+rule "Test Parse"
+
+when
+    eval( 3==3 )
+then
+    System.out.println("OK");
+end 

--- a/drools-parser/src/test/resources/org/drools/parser/eval_with_newline.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/eval_with_newline.drl
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+    Foo()
+    Bar()
+    eval(
+
+
+
+           abc(
+
+           "foo") +
+           5
+
+
+
+
+           )
+  then
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/expander_multiple_constraints.dslr
+++ b/drools-parser/src/test/resources/org/drools/parser/expander_multiple_constraints.dslr
@@ -1,0 +1,18 @@
+//created on: 13/04/2006
+package mydsl
+
+
+expander multiple_constraints.dsl
+
+
+rule "Your First Rule"
+
+    when
+        There is a Person with
+            -   age less than 42
+            -location is 'atlanta'
+        Bar bar black sheep
+    then
+        Log "hola bob"
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/expander_multiple_constraints_flush.dslr
+++ b/drools-parser/src/test/resources/org/drools/parser/expander_multiple_constraints_flush.dslr
@@ -1,0 +1,17 @@
+//created on: 13/04/2006
+package mydsl
+
+
+expander multiple_constraints.dsl
+
+
+rule "Your First Rule"
+
+    when
+        There is a Person with
+            -age less than 42
+            -location is 'atlanta'
+    then
+        Log "hola bob"
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/expander_spread_lines.dslr
+++ b/drools-parser/src/test/resources/org/drools/parser/expander_spread_lines.dslr
@@ -1,0 +1,19 @@
+//created on: 13/04/2006
+package mydsl
+
+
+expander complex.dsl
+
+
+rule "Your First Rule"
+
+    when
+        Person is at least 42 years old and lives in atlanta
+
+            Or
+
+        There is a Person with name of bob
+    then
+        Log "hola bob"
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/extra_lhs_newline.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/extra_lhs_newline.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule "another test"
+    when
+        s : String()
+        eval(s.equals("foo") && s.startsWith("f"))
+        
+        
+    then
+        list.add( s );
+end 

--- a/drools-parser/src/test/resources/org/drools/parser/forall.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/forall.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "ForallParserTest"
+when
+     forall( Person( age > 21, $likes : likes )
+             Cheese( type == $likes ) );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/forallwithfrom.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/forallwithfrom.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "ForallParserTest"
+when
+     forall( Person( age > 21, $likes : likes ) from $village
+             Cheese( type == $likes ) from $cheesery );
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/functions.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/functions.drl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+import java.lang.String
+
+function String functionA(String s, Integer i) {
+
+    foo();
+
+}
+
+function void functionB() {
+    bar();
+}
+
+
+rule something 
+    when
+    then
+end
+
+rule "one more thing"
+    when
+    then
+end
+
+
+

--- a/drools-parser/src/test/resources/org/drools/parser/in_operator_test.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/in_operator_test.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+//testing 'in' operator
+
+rule simple_rule 
+  when
+      Person(age > 30 && < 40)
+      Vehicle(type in ( "sedan", "wagon" ), age < 3)
+  then
+    consequence();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/lhs_semicolon_delim.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/lhs_semicolon_delim.drl
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+    foo3 : Bar(a==3) ; foo4 : Bar(a4:a==4) ; Baz()
+  then
+  if ( a == b ) {
+    assert( foo3 );
+  } else {
+    retract( foo4 );
+  } 
+  System.out.println( a4 );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/multiple_constraints.dsl
+++ b/drools-parser/src/test/resources/org/drools/parser/multiple_constraints.dsl
@@ -1,0 +1,6 @@
+#place your comments here - this is just a description for your own purposes.
+[when]There is a Person with=Person()
+[when]- age less than {age}=age < {age}
+[when]- location is '{city}'=location=={city}
+[when]Bar bar black sheep=Bar()
+[then]Log "{message}"=System.out.println("{message}");

--- a/drools-parser/src/test/resources/org/drools/parser/multiple_rules.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/multiple_rules.drl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+import org.drools.integrationtests.Cheese;
+
+rule "Like Stilton"
+    when
+        Cheese( t:type == "stilton" )
+    then
+        System.out.println("I like " + t);
+end    
+
+rule "Like Cheddar"
+    when
+        Cheese( t:type == "cheddar" )
+    then
+        System.out.println("I like " + t );
+end    

--- a/drools-parser/src/test/resources/org/drools/parser/nested_conditional_elements.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/nested_conditional_elements.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule "test nested CEs"
+    when
+        not ( State( $state : state ) and
+              not( Person( status == $state, $likes : likes ) and
+                   Cheese( type == $likes ) ) )
+        Person( name == "Bob" )
+        ( Cheese( price == 10 ) or Cheese( type == "brie" ) )
+    then
+        results.add("OK");
+end

--- a/drools-parser/src/test/resources/org/drools/parser/not_exist_with_brackets.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/not_exist_with_brackets.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package HR1
+
+rule simple_rule 
+  when
+      not ( Cheese(type == "stilton") )
+      exists ( Foo() )
+  then
+    funky();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/not_with_constraint.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/not_with_constraint.drl
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+
+global java.util.List list;
+global java.lang.Integer five;
+
+rule "not rule test"
+    when
+        $person : Person( $likes:like )
+        not Cheese( type == $likes )
+    then
+        list.add( $person );
+end    

--- a/drools-parser/src/test/resources/org/drools/parser/notin_operator_test.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/notin_operator_test.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+//testing not 'in' operator
+
+rule simple_rule 
+  when
+      Person(age > 30 && < 40)
+      Vehicle(type not in ( "sedan", "wagon" ), age < 3)
+  then
+    consequence();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/or_binding.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/or_binding.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+import org.drools.compiler.Person
+
+rule simple_rule 
+  when
+    foo :  ( Person(name == "mark") or Person(type == "fan") )
+    Cheese(type == "green")
+  then
+    System.out.println( "Mark and Michael" + bar );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/or_binding_complex.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/or_binding_complex.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+rule simple_rule 
+  when
+    foo : ( Person(name == "mark")
+        or
+        Person(type == "fan") )
+  then
+    System.out.println( "Mark and Michael" + bar );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/or_binding_with_brackets.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/or_binding_with_brackets.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+rule simple_rule 
+  when
+    foo : (
+        Person(name == "mark") or Person(type == "fan")
+        )
+  then
+    System.out.println( "Mark and Michael" + bar );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/or_ce.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/or_ce.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule "testing OR CE"
+when
+    $p : Person( name == "bob" )
+    $c : Cheese( type == $p.likes ) or Cheese( price == 10 )
+then
+    // do something
+end 

--- a/drools-parser/src/test/resources/org/drools/parser/or_nesting.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/or_nesting.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+import org.drools.compiler.Person
+
+rule simple_rule 
+  when
+    Person(name == "mark") or
+    ( Person(type == "fan") and Cheese(type == "green") )
+  then
+    System.out.println( "Mark and Michael" + bar );
+end

--- a/drools-parser/src/test/resources/org/drools/parser/package_attributes.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/package_attributes.drl
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.foo;
+
+agenda-group "x"
+
+import goo.ber
+import wee.waa
+
+
+dialect "java"
+
+
+
+
+rule bar
+  when
+  then
+end
+
+rule baz
+  dialect "mvel"
+  when
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/pluggable_operators.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/pluggable_operators.drl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+rule "test pluggable operators"
+when
+    $a : EventA()
+    $b : EventB( this after[1,10] $a || this not after[15,20] $a )
+    $c : EventC( this finishes $b )
+    $d : EventD( this not starts $a )
+    $e : EventE( this not before[1, 10] $b || after[1, 10] $c && this after[1, 5] $d )
+then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/qualified_classname.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/qualified_classname.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+rule "Who likes Stilton"
+    when
+        com.cheeseco.Cheese($type : type == "stilton")
+    then
+        System.out.println( $name + " likes " + $type);
+end    

--- a/drools-parser/src/test/resources/org/drools/parser/query_and_rule.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/query_and_rule.drl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+package foo
+
+rule bar
+    when
+        Baz()
+    then
+        Boo()
+end
+
+query "simple_query" 
+    foo3 : Bar(a==3)
+    foo4 : Bar(a4:a==4)
+    Baz()
+
+end
+
+rule bar2
+    when
+        Baz()
+    then
+        Boo()
+end
+
+query "simple_query2" 
+    foo3 : Bar(a==3)
+    foo4 : Bar(a4:a==4)
+    Baz()
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_attributes.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_attributes.drl
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+
+rule simple_rule 
+        // attributes keywork (and colon) is totally optional
+        salience 42
+        agenda-group "my_group"
+        no-loop
+        duration 42
+        activation-group "my_activation_group"
+        lock-on-active true
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_attributes2.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_attributes2.drl
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package foo.bar
+
+
+rule rule1 
+        salience (42)
+        agenda-group "my_group"
+    when
+        Foo()
+    then
+        bar();
+end
+
+rule rule2 
+        salience (Integer.MIN_VALUE)
+        no-loop
+    when
+        Foo()
+    then
+        bar();
+end
+
+rule rule3 
+        enabled (Boolean.TRUE)
+        activation-group "my_activation_group"
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_attributes_alt.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_attributes_alt.drl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+
+rule simple_rule 
+    attributes:
+        salience 42, agenda-group "my_group", no-loop,  lock-on-active, duration 42, activation-group "my_activation_group"
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_calendars_attribute.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_calendars_attribute.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+        calendars "cal1"
+        lock-on-active true
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_calendars_attribute2.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_calendars_attribute2.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+        calendars "cal 1", "cal 2", "cal 3"
+        lock-on-active true
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_duration_expression.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_duration_expression.drl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+        duration ( 1h30m )
+        lock-on-active true
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_enabled_expression.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_enabled_expression.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+        enabled ( 1 + 1 == 2 )
+        salience ( 1+2 )
+        lock-on-active true
+    when
+        Foo()
+    then
+        bar();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_names_number_prefix.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_names_number_prefix.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule "1. Do Stuff!"
+  when
+  then
+end
+
+rule "2. Do More Stuff!"
+  when
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/rule_not.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/rule_not.drl
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+      not Cheese(type == "stilton")
+  then
+    funky();
+end

--- a/drools-parser/src/test/resources/org/drools/parser/semicolon.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/semicolon.drl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.mvel.compiler
+
+global java.util.List list;
+
+rule "rule1"
+when
+    Pattern1();
+    Pattern2() from x.y.z;
+then
+    System.out.println("Test");
+end;
+
+query "query1"
+    Pattern5();
+    Pattern6();
+    Pattern7();
+end;
+
+rule "rule2"
+when
+    Pattern3();
+    Pattern4() from collect( Pattern5() );
+then
+    System.out.println("Test");
+end;
+

--- a/drools-parser/src/test/resources/org/drools/parser/simple_query.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/simple_query.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+query "simple_query" 
+    foo3 : Bar(a==3)
+    foo4 : Bar(a4:a==4)
+    Baz()
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/soundslike_operator.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/soundslike_operator.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package nesting;
+
+
+
+
+rule "test something"
+
+    when
+        p: Person( name soundslike "Michael" )
+    then
+        p.name = "goober"
+        System.out.println(p.name)
+end

--- a/drools-parser/src/test/resources/org/drools/parser/statement_ordering_1.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/statement_ordering_1.drl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+package com.foo;
+
+import im.one
+
+import im.two
+
+rule foo
+  when
+  then
+end
+
+function cheeseIt() {
+
+}
+
+import im.three;
+
+rule bar
+  when
+  then
+end
+
+function uncheeseIt() {
+
+}
+
+import im.four;

--- a/drools-parser/src/test/resources/org/drools/parser/test_CommentLineNumbersInConsequence.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/test_CommentLineNumbersInConsequence.drl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package la
+
+
+rule simple_rule 
+  when
+      Baz()
+  then
+      //woot
+      first
+
+      //
+
+      /* lala
+
+      */
+      second
+end

--- a/drools-parser/src/test/resources/org/drools/parser/test_EndPosition.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/test_EndPosition.drl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+
+rule simple_rule 
+  when
+    Foo(
+      bar == baz, la==laz
+      )
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/type_with_meta.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/type_with_meta.drl
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+declare NetworkNode
+            locElevation: java.math.BigDecimal
+            name: String @key
+            nodeClass: String
+            locLongitude: java.math.BigDecimal
+            nodeType: String
+            locLatitude: java.math.BigDecimal
+end
+
+declare NetworkConnection
+            id: String @key
+            node1: NetworkNode
+            node2: NetworkNode
+            hops: Integer
+end
+
+declare NetworkEvent
+            @role( event )
+            @timestamp( creationTime )
+
+            id: String @key
+            locElevation: java.math.BigDecimal
+            description: String
+            sourceComponent: NetworkNode
+            locLongitude: java.math.BigDecimal
+            severity: Integer
+            creationTime: java.util.Date
+            locLatitude: java.math.BigDecimal
+end

--- a/drools-parser/src/test/resources/org/drools/parser/with_eval.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/with_eval.drl
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+    Foo()
+    Bar()
+    eval(abc("foo"))
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/with_predicate.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/with_predicate.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+      Person( $age2:age, $age2 == $age1+2 )
+  then
+end

--- a/drools-parser/src/test/resources/org/drools/parser/with_retval.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/with_retval.drl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+rule simple_rule 
+  when
+    Foo(name== (a + b))
+  then
+end


### PR DESCRIPTION
…sabled and priority comment

https://issues.redhat.com/browse/DROOLS-7271

Currently, I'm porting RuleParserTest (https://github.com/tkobayas/drools/blob/main/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java) test methods to MiscDRLParserTest fixing issues one by one. However, with this JIRA, I port all RuleParserTest test methods to MiscDRLParserTest and set `@Disabled` on failing tests. Also add comments on the `@Disabled` to describe the priority (and some notes) so that we can grab the overview and work on fixes of higher priority issues later on. It would also help contributors to fix unresolved issues in the test class.

So this PR is just to port test methods. Not including a fix.

Note that these test methods are just ported (with assertj conversion), but if you have any suggestions to improve the tests, it would be welcome and I will handle it with another JIRA.