### PR TITLE
[DROOLS-7591] Experiment branch : migrate a new drools-lsp parser int…

### DIFF
--- a/drools-parser/src/main/java/org/drools/parser/DRLParserHelper.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserHelper.java
@@ -1,5 +1,9 @@
 package org.drools.parser;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -28,8 +32,21 @@ public class DRLParserHelper {
     }
 
     public static DRLParser createDrlParser(String drl) {
-        CharStream inputStream = CharStreams.fromString(drl);
-        DRLLexer drlLexer = new DRLLexer(inputStream);
+        CharStream charStream = CharStreams.fromString(drl);
+        return createDrlParser(charStream);
+    }
+
+    public static DRLParser createDrlParser(InputStream is) {
+        try {
+            CharStream charStream = CharStreams.fromStream(is);
+            return createDrlParser(charStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static DRLParser createDrlParser(CharStream charStream) {
+        DRLLexer drlLexer = new DRLLexer(charStream);
         CommonTokenStream commonTokenStream = new CommonTokenStream(drlLexer);
         return new DRLParser(commonTokenStream);
     }

--- a/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
@@ -1,5 +1,6 @@
 package org.drools.parser;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +25,18 @@ public class DRLParserWrapper {
      */
     public PackageDescr parse(String drl) {
         DRLParser drlParser = DRLParserHelper.createDrlParser(drl);
+        return parse(drlParser);
+    }
+
+    /**
+     * Main entry point for parsing DRL
+     */
+    public PackageDescr parse(InputStream is) {
+        DRLParser drlParser = DRLParserHelper.createDrlParser(is);
+        return parse(drlParser);
+    }
+
+    private PackageDescr parse(DRLParser drlParser) {
         DRLErrorListener errorListener = new DRLErrorListener();
         drlParser.addErrorListener(errorListener);
 


### PR DESCRIPTION
…o drools

- Add some methods to call from drools code base

These are small pieces required on the drools-lsp side in order to test the new parser migration experiment.
