### PR TITLE
Fix vscode-test on Windows

### DIFF
--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -12,8 +12,11 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+		// Use win64 instead of win32 for testing Windows
+		const platform = process.platform === 'win32' ? 'win32-x64-archive' : undefined;
+
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({ extensionDevelopmentPath, extensionTestsPath, platform });
 	} catch (err) {
 		console.error('Failed to run tests');
 		process.exit(1);


### PR DESCRIPTION
https://code.visualstudio.com/docs/supporting/faq#_previous-release-versions

Windows x86 32-bit versions are no longer actively supported after release 1.83 and could pose a security risk.

See https://github.com/microsoft/vscode-test how to change the platform.