### PR TITLE
Java class completion in LHS Patterns

### DIFF
--- a/.github/workflows/drools-lsp-pr.yml
+++ b/.github/workflows/drools-lsp-pr.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build with Maven
         run: mvn -B clean install
 
+      - name: Compile testFixture
+        run: mvn -f client/src/testFixture/pom.xml compile
+
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -71,8 +71,10 @@ export function activate(context: vscode.ExtensionContext) {
         console.log('serverOptions ' + serverOptions);
         // Options to control the language client
         let clientOptions: LanguageClientOptions = {
-            // Register the server for plain text documents
-            documentSelector: [{scheme: 'file', language: 'drools'}]
+            documentSelector: [{scheme: 'file', language: 'drools'}],
+            synchronize: {
+                fileEvents: vscode.workspace.createFileSystemWatcher('**/target/classes/**/*.class')
+            }
         };
         // Create the language client and start the client.
         let languageClient: LanguageClient = new LanguageClient('Drools', 'DRL Language Server', serverOptions, clientOptions);

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -15,8 +15,16 @@ async function main() {
 		// Use win64 instead of win32 for testing Windows
 		const platform = process.platform === 'win32' ? 'win32-x64-archive' : undefined;
 
+		// The workspace folder for the test — a Maven project with domain classes
+		const testWorkspace = path.resolve(__dirname, '../../src/testFixture');
+
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath, platform });
+		await runTests({
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			platform,
+			launchArgs: [testWorkspace]
+		});
 	} catch (err) {
 		console.error('Failed to run tests');
 		process.exit(1);

--- a/client/src/test/suite/completion.test.ts
+++ b/client/src/test/suite/completion.test.ts
@@ -19,6 +19,45 @@ suite('Completion tests', () => {
 	}).timeout(20000); // increase timeout from the default 2000ms because helper.activate waits 2000ms for server startup
 });
 
+suite('Class completion tests', () => {
+	const docUri = getDocUri('sample.drl');
+
+	test('Suggests class names in pattern position', async () => {
+		await activate(docUri);
+
+		// Line 13: "$p :" in the "greeting" rule — caret after the colon
+		const position = new vscode.Position(13, 7);
+
+		const actualCompletionList = (await vscode.commands.executeCommand(
+			'vscode.executeCompletionItemProvider',
+			docUri,
+			position
+		)) as vscode.CompletionList;
+
+		// Person and Address are compiled domain classes in testFixture/target/classes
+		const classLabels = actualCompletionList.items
+			.filter(item => item.kind === vscode.CompletionItemKind.Class)
+			.map(item => item.label);
+
+		assert.ok(classLabels.includes('Person'), 'Should suggest Person class');
+		assert.ok(classLabels.includes('Address'), 'Should suggest Address class');
+
+		// Person is imported, so should have sortText starting with "0_"
+		const personItem = actualCompletionList.items.find(
+			item => item.label === 'Person' && item.kind === vscode.CompletionItemKind.Class
+		);
+		assert.ok(personItem, 'Person completion item should exist');
+		assert.ok(personItem!.sortText?.startsWith('0_'), 'Imported Person should be ranked first');
+
+		// Address is not imported, so should have sortText starting with "1_"
+		const addressItem = actualCompletionList.items.find(
+			item => item.label === 'Address' && item.kind === vscode.CompletionItemKind.Class
+		);
+		assert.ok(addressItem, 'Address completion item should exist');
+		assert.ok(addressItem!.sortText?.startsWith('1_'), 'Unimported Address should be ranked after imported classes');
+	}).timeout(30000); // classpath resolution via mvn adds time
+});
+
 async function testCompletion(
 	docUri: vscode.Uri,
 	position: vscode.Position,

--- a/client/src/test/suite/completion.test.ts
+++ b/client/src/test/suite/completion.test.ts
@@ -28,19 +28,34 @@ suite('Class completion tests', () => {
 		// Line 13: "$p :" in the "greeting" rule — caret after the colon
 		const position = new vscode.Position(13, 7);
 
+		// Class index is built asynchronously after initialize; retry until ready
+		let classLabels: string[] = [];
+		for (let attempt = 0; attempt < 15; attempt++) {
+			const completionList = (await vscode.commands.executeCommand(
+				'vscode.executeCompletionItemProvider',
+				docUri,
+				position
+			)) as vscode.CompletionList;
+
+			classLabels = completionList.items
+				.filter(item => item.kind === vscode.CompletionItemKind.Class)
+				.map(item => item.label as string);
+
+			if (classLabels.includes('Person')) {
+				break;
+			}
+			await new Promise(resolve => setTimeout(resolve, 1000));
+		}
+
+		assert.ok(classLabels.includes('Person'), 'Should suggest Person class');
+		assert.ok(classLabels.includes('Address'), 'Should suggest Address class');
+
+		// Re-query to check sortText on the final result
 		const actualCompletionList = (await vscode.commands.executeCommand(
 			'vscode.executeCompletionItemProvider',
 			docUri,
 			position
 		)) as vscode.CompletionList;
-
-		// Person and Address are compiled domain classes in testFixture/target/classes
-		const classLabels = actualCompletionList.items
-			.filter(item => item.kind === vscode.CompletionItemKind.Class)
-			.map(item => item.label);
-
-		assert.ok(classLabels.includes('Person'), 'Should suggest Person class');
-		assert.ok(classLabels.includes('Address'), 'Should suggest Address class');
 
 		// Person is imported, so should have sortText starting with "0_"
 		const personItem = actualCompletionList.items.find(

--- a/client/src/test/suite/helper.ts
+++ b/client/src/test/suite/helper.ts
@@ -32,7 +32,7 @@ async function sleep(ms: number) {
 }
 
 export const getDocPath = (p: string) => {
-	return path.resolve(__dirname, '../../../src/testFixture', p);
+	return path.resolve(__dirname, '../../../src/testFixture/src/main/resources/rules', p);
 };
 export const getDocUri = (p: string) => {
 	return vscode.Uri.file(getDocPath(p));

--- a/client/src/testFixture/pom.xml
+++ b/client/src/testFixture/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>drools-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-completion</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/client/src/testFixture/src/main/java/org/example/model/Address.java
+++ b/client/src/testFixture/src/main/java/org/example/model/Address.java
@@ -1,0 +1,31 @@
+package org.example.model;
+
+public class Address {
+
+    private String street;
+    private String city;
+
+    public Address() {
+    }
+
+    public Address(String street, String city) {
+        this.street = street;
+        this.city = city;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+}

--- a/client/src/testFixture/src/main/java/org/example/model/Person.java
+++ b/client/src/testFixture/src/main/java/org/example/model/Person.java
@@ -1,0 +1,31 @@
+package org.example.model;
+
+public class Person {
+
+    private String name;
+    private int age;
+
+    public Person() {
+    }
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/client/src/testFixture/src/main/resources/rules/sample.drl
+++ b/client/src/testFixture/src/main/resources/rules/sample.drl
@@ -1,0 +1,17 @@
+package org.example.rules;
+
+import org.example.model.Person;
+
+rule "adult check"
+  when
+    $p : Person(age >= 18)
+  then
+    System.out.println($p.getName() + " is an adult");
+end
+
+rule "greeting"
+  when
+    $p :
+  then
+    System.out.println("Hello");
+end

--- a/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
@@ -40,6 +40,10 @@ public class ClassIndex {
         return new ClassIndex(index);
     }
 
+    public List<String> getAll() {
+        return getMatching("");
+    }
+
     public List<String> getMatching(String prefix) {
         List<String> result = new ArrayList<>();
         for (Map.Entry<String, List<String>> entry : index.entrySet()) {

--- a/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
@@ -1,0 +1,94 @@
+package org.drools.completion;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+public class ClassIndex {
+
+    private static final Logger logger = Logger.getLogger(ClassIndex.class.getName());
+
+    private final Map<String, List<String>> index;
+
+    private ClassIndex(Map<String, List<String>> index) {
+        this.index = index;
+    }
+
+    public static ClassIndex empty() {
+        return new ClassIndex(new HashMap<>());
+    }
+
+    public static ClassIndex build(Set<Path> classpathEntries) {
+        Map<String, List<String>> index = new HashMap<>();
+        for (Path entry : classpathEntries) {
+            if (Files.isDirectory(entry)) {
+                scanDirectory(entry, index);
+            } else if (entry.toString().endsWith(".jar") && Files.isRegularFile(entry)) {
+                scanJar(entry, index);
+            }
+        }
+        return new ClassIndex(index);
+    }
+
+    public List<String> getMatching(String prefix) {
+        List<String> result = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : index.entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                result.addAll(entry.getValue());
+            }
+        }
+        result.sort(String::compareTo);
+        return result;
+    }
+
+    public int size() {
+        return index.values().stream().mapToInt(List::size).sum();
+    }
+
+    private static void scanDirectory(Path dir, Map<String, List<String>> index) {
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.filter(p -> p.toString().endsWith(".class"))
+                .forEach(p -> {
+                    String relative = dir.relativize(p).toString();
+                    addClassEntry(relative, index);
+                });
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to scan directory: " + dir, e);
+        }
+    }
+
+    private static void scanJar(Path jarPath, Map<String, List<String>> index) {
+        try (JarFile jar = new JarFile(jarPath.toFile())) {
+            jar.stream()
+                .map(JarEntry::getName)
+                .filter(name -> name.endsWith(".class"))
+                .forEach(name -> addClassEntry(name, index));
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to scan JAR: " + jarPath, e);
+        }
+    }
+
+    private static void addClassEntry(String path, Map<String, List<String>> index) {
+        String fqcn = path.replace('/', '.').replace('\\', '.');
+        if (fqcn.endsWith(".class")) {
+            fqcn = fqcn.substring(0, fqcn.length() - ".class".length());
+        }
+
+        String simpleName = fqcn.contains(".") ? fqcn.substring(fqcn.lastIndexOf('.') + 1) : fqcn;
+        if (simpleName.contains("$") || simpleName.equals("module-info") || simpleName.equals("package-info")) {
+            return;
+        }
+
+        index.computeIfAbsent(simpleName, k -> new ArrayList<>()).add(fqcn);
+    }
+}

--- a/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassIndex.java
@@ -40,6 +40,18 @@ public class ClassIndex {
         return new ClassIndex(index);
     }
 
+    public static ClassIndex merge(ClassIndex base, ClassIndex overlay) {
+        Map<String, List<String>> merged = new HashMap<>(base.index);
+        for (Map.Entry<String, List<String>> entry : overlay.index.entrySet()) {
+            merged.merge(entry.getKey(), entry.getValue(), (a, b) -> {
+                List<String> combined = new ArrayList<>(a);
+                combined.addAll(b);
+                return combined;
+            });
+        }
+        return new ClassIndex(merged);
+    }
+
     public List<String> getAll() {
         return getMatching("");
     }

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -57,17 +57,17 @@ public class DRLCompletionHelper {
         int row = caretPosition == null ? -1 : caretPosition.getLine() + 1; // caret line position is zero based
         int col = caretPosition == null ? -1 : caretPosition.getCharacter();
 
-        drlParser.compilationUnit();
+        DRL10Parser.CompilationUnitContext compilationUnit = drlParser.compilationUnit();
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
 
-        return getCompletionItems(drlParser, nodeIndex, text, classIndex);
+        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
         return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty());
     }
 
-    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, String text, ClassIndex classIndex) {
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -82,8 +82,8 @@ public class DRLCompletionHelper {
                 .map(k -> createCompletionItem(k, CompletionItemKind.Keyword))
                 .collect(Collectors.toList());
 
-        if (text != null && classIndex.size() > 0 && isPatternPosition(candidates)) {
-            items.addAll(getClassCompletionItems(text, classIndex));
+        if (compilationUnit != null && classIndex.size() > 0 && isPatternPosition(candidates)) {
+            items.addAll(getClassCompletionItems(compilationUnit, classIndex));
         }
 
         return items;
@@ -98,8 +98,8 @@ public class DRLCompletionHelper {
             || path.contains(DRL10Parser.RULE_lhsPatternBind);
     }
 
-    private static List<CompletionItem> getClassCompletionItems(String text, ClassIndex classIndex) {
-        Set<String> importedFqcns = parseImports(text);
+    private static List<CompletionItem> getClassCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex) {
+        Set<String> importedFqcns = extractImports(compilationUnit);
         List<String> matchingFqcns = classIndex.getMatching("");
         List<CompletionItem> items = new ArrayList<>();
 
@@ -123,18 +123,12 @@ public class DRLCompletionHelper {
         return items;
     }
 
-    private static Set<String> parseImports(String text) {
+    private static Set<String> extractImports(DRL10Parser.CompilationUnitContext compilationUnit) {
         Set<String> imports = new HashSet<>();
-        for (String line : text.split("\n")) {
-            String trimmed = line.trim();
-            if (trimmed.startsWith("import ")) {
-                String importStr = trimmed.substring("import ".length()).trim();
-                if (importStr.endsWith(";")) {
-                    importStr = importStr.substring(0, importStr.length() - 1).trim();
-                }
-                if (!importStr.startsWith("static ") && !importStr.startsWith("function ")
-                    && !importStr.startsWith("accumulate ") && !importStr.startsWith("acc ")) {
-                    imports.add(importStr);
+        for (DRL10Parser.DrlStatementdefContext stmt : compilationUnit.drlStatementdef()) {
+            if (stmt.importdef() instanceof DRL10Parser.ImportStandardDefContext importDef) {
+                if (importDef.DRL_FUNCTION() == null && importDef.STATIC() == null) {
+                    imports.add(importDef.drlQualifiedName().getText());
                 }
             }
         }

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -100,7 +100,8 @@ public class DRLCompletionHelper {
 
     private static List<CompletionItem> getClassCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex) {
         Set<String> importedFqcns = extractImports(compilationUnit);
-        List<String> matchingFqcns = classIndex.getMatching("");
+        // LSP clients filter completions by typed prefix, so we return all classes
+        List<String> matchingFqcns = classIndex.getAll();
         List<CompletionItem> items = new ArrayList<>();
 
         for (String fqcn : matchingFqcns) {

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.vmware.antlr4c3.CodeCompletionCore;
+import org.antlr.v4.runtime.Token;
 import org.drools.drl.parser.antlr4.DRL10Lexer;
 import org.drools.drl.parser.antlr4.DRL10Parser;
 import org.eclipse.lsp4j.CompletionItem;
@@ -59,15 +60,16 @@ public class DRLCompletionHelper {
 
         DRL10Parser.CompilationUnitContext compilationUnit = drlParser.compilationUnit();
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
+        String prefix = extractPrefix(drlParser, nodeIndex);
 
-        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex);
+        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
-        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty());
+        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "");
     }
 
-    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex) {
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -83,7 +85,7 @@ public class DRLCompletionHelper {
                 .collect(Collectors.toList());
 
         if (compilationUnit != null && classIndex.size() > 0 && isPatternPosition(candidates)) {
-            items.addAll(getClassCompletionItems(compilationUnit, classIndex));
+            items.addAll(getClassCompletionItems(compilationUnit, classIndex, prefix));
         }
 
         return items;
@@ -98,10 +100,9 @@ public class DRLCompletionHelper {
             || path.contains(DRL10Parser.RULE_lhsPatternBind);
     }
 
-    private static List<CompletionItem> getClassCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex) {
+    private static List<CompletionItem> getClassCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix) {
         Set<String> importedFqcns = extractImports(compilationUnit);
-        // LSP clients filter completions by typed prefix, so we return all classes
-        List<String> matchingFqcns = classIndex.getAll();
+        List<String> matchingFqcns = classIndex.getMatching(prefix);
         List<CompletionItem> items = new ArrayList<>();
 
         for (String fqcn : matchingFqcns) {
@@ -134,6 +135,18 @@ public class DRLCompletionHelper {
             }
         }
         return imports;
+    }
+
+    private static String extractPrefix(DRL10Parser drlParser, Integer nodeIndex) {
+        if (nodeIndex == null || nodeIndex < 0 || nodeIndex >= drlParser.getInputStream().size()) {
+            return "";
+        }
+        Token token = drlParser.getInputStream().get(nodeIndex);
+        String text = token.getText();
+        if (text != null && !text.isEmpty() && Character.isJavaIdentifierStart(text.charAt(0))) {
+            return text;
+        }
+        return "";
     }
 
     static CompletionItem createCompletionItem(String label, CompletionItemKind itemKind) {

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -48,6 +48,10 @@ public class DRLCompletionHelper {
     }
 
     public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client) {
+        return getCompletionItems(text, caretPosition, client, ClassIndex.empty());
+    }
+
+    public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client, ClassIndex classIndex) {
         DRL10Parser drlParser = createDrlParser(text);
 
         int row = caretPosition == null ? -1 : caretPosition.getLine() + 1; // caret line position is zero based
@@ -56,10 +60,14 @@ public class DRLCompletionHelper {
         drlParser.compilationUnit();
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
 
-        return getCompletionItems(drlParser, nodeIndex);
+        return getCompletionItems(drlParser, nodeIndex, text, classIndex);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
+        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty());
+    }
+
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, String text, ClassIndex classIndex) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -68,11 +76,25 @@ public class DRLCompletionHelper {
             candidates.tokens.put(DRL10Lexer.DRL_RHS_END, List.of());
         }
 
-        return candidates.tokens.keySet().stream().filter(Objects::nonNull)
+        List<CompletionItem> items = candidates.tokens.keySet().stream().filter(Objects::nonNull)
                 .map(integer -> drlParser.getVocabulary().getDisplayName(integer).replace("'", ""))
                 .map(String::toLowerCase)
                 .map(k -> createCompletionItem(k, CompletionItemKind.Keyword))
                 .collect(Collectors.toList());
+
+        if (text != null && classIndex.size() > 0 && isPatternPosition(candidates)) {
+            items.addAll(getClassCompletionItems(text, classIndex));
+        }
+
+        return items;
+    }
+
+    private static boolean isPatternPosition(CodeCompletionCore.CandidatesCollection candidates) {
+        return false; // stub — implemented in Task 4
+    }
+
+    private static List<CompletionItem> getClassCompletionItems(String text, ClassIndex classIndex) {
+        return List.of(); // stub — implemented in Task 4
     }
 
     static CompletionItem createCompletionItem(String label, CompletionItemKind itemKind) {

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -112,9 +112,9 @@ public class DRLCompletionHelper {
             item.setInsertText(simpleName);
 
             if (importedFqcns.contains(fqcn)) {
-                item.setSortText("0_" + simpleName);
+                item.setSortText("0_" + simpleName + "_" + fqcn);
             } else {
-                item.setSortText("1_" + simpleName);
+                item.setSortText("1_" + simpleName + "_" + fqcn);
             }
 
             items.add(item);

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -90,11 +90,55 @@ public class DRLCompletionHelper {
     }
 
     private static boolean isPatternPosition(CodeCompletionCore.CandidatesCollection candidates) {
-        return false; // stub — implemented in Task 4
+        List<Integer> path = candidates.rules.get(DRL10Parser.RULE_drlQualifiedName);
+        if (path == null) {
+            return false;
+        }
+        return path.contains(DRL10Parser.RULE_lhsPattern)
+            || path.contains(DRL10Parser.RULE_lhsPatternBind);
     }
 
     private static List<CompletionItem> getClassCompletionItems(String text, ClassIndex classIndex) {
-        return List.of(); // stub — implemented in Task 4
+        Set<String> importedFqcns = parseImports(text);
+        List<String> matchingFqcns = classIndex.getMatching("");
+        List<CompletionItem> items = new ArrayList<>();
+
+        for (String fqcn : matchingFqcns) {
+            String simpleName = fqcn.substring(fqcn.lastIndexOf('.') + 1);
+            CompletionItem item = new CompletionItem();
+            item.setLabel(simpleName);
+            item.setDetail(fqcn);
+            item.setKind(CompletionItemKind.Class);
+            item.setInsertText(simpleName);
+
+            if (importedFqcns.contains(fqcn)) {
+                item.setSortText("0_" + simpleName);
+            } else {
+                item.setSortText("1_" + simpleName);
+            }
+
+            items.add(item);
+        }
+
+        return items;
+    }
+
+    private static Set<String> parseImports(String text) {
+        Set<String> imports = new HashSet<>();
+        for (String line : text.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("import ")) {
+                String importStr = trimmed.substring("import ".length()).trim();
+                if (importStr.endsWith(";")) {
+                    importStr = importStr.substring(0, importStr.length() - 1).trim();
+                }
+                if (!importStr.startsWith("static ") && !importStr.startsWith("function ")
+                    && !importStr.startsWith("accumulate ") && !importStr.startsWith("acc ")) {
+                    imports.add(importStr);
+                }
+            }
+        }
+        return imports;
     }
 
     static CompletionItem createCompletionItem(String label, CompletionItemKind itemKind) {

--- a/drools-completion/src/test/java/org/drools/completion/ClassIndexTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/ClassIndexTest.java
@@ -89,4 +89,26 @@ class ClassIndexTest {
         assertThat(index.getMatching("Any")).isEmpty();
         assertThat(index.size()).isEqualTo(0);
     }
+
+    @Test
+    void mergeIndices() throws IOException {
+        Path classesDir = tempDir.resolve("classes");
+        Files.createDirectories(classesDir.resolve("org/example"));
+        Files.createFile(classesDir.resolve("org/example/Person.class"));
+
+        Path jarPath = tempDir.resolve("dep.jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new java.util.jar.JarEntry("com/acme/Order.class"));
+            jos.closeEntry();
+        }
+
+        ClassIndex dirIndex = ClassIndex.build(Set.of(classesDir));
+        ClassIndex jarIndex = ClassIndex.build(Set.of(jarPath));
+        ClassIndex merged = ClassIndex.merge(jarIndex, dirIndex);
+
+        assertThat(merged.getMatching("Per")).containsExactly("org.example.Person");
+        assertThat(merged.getMatching("Or")).containsExactly("com.acme.Order");
+        assertThat(merged.size()).isEqualTo(2);
+    }
 }

--- a/drools-completion/src/test/java/org/drools/completion/ClassIndexTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/ClassIndexTest.java
@@ -1,0 +1,92 @@
+package org.drools.completion;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClassIndexTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void scanDirectory() throws IOException {
+        Path classesDir = tempDir.resolve("target/classes");
+        Path personClass = classesDir.resolve("org/example/Person.class");
+        Files.createDirectories(personClass.getParent());
+        Files.createFile(personClass);
+
+        Path addressClass = classesDir.resolve("org/example/Address.class");
+        Files.createFile(addressClass);
+
+        // Inner class should be skipped
+        Path innerClass = classesDir.resolve("org/example/Person$Builder.class");
+        Files.createFile(innerClass);
+
+        // module-info should be skipped
+        Path moduleInfo = classesDir.resolve("module-info.class");
+        Files.createFile(moduleInfo);
+
+        ClassIndex index = ClassIndex.build(Set.of(classesDir));
+
+        assertThat(index.getMatching("Per")).containsExactly("org.example.Person");
+        assertThat(index.getMatching("Addr")).containsExactly("org.example.Address");
+        assertThat(index.getMatching("Person$")).isEmpty();
+        assertThat(index.getMatching("module")).isEmpty();
+    }
+
+    @Test
+    void scanJar() throws IOException {
+        Path jarPath = tempDir.resolve("test.jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new java.util.jar.JarEntry("com/acme/Order.class"));
+            jos.closeEntry();
+            jos.putNextEntry(new java.util.jar.JarEntry("com/acme/Order$Item.class"));
+            jos.closeEntry();
+            jos.putNextEntry(new java.util.jar.JarEntry("com/acme/Product.class"));
+            jos.closeEntry();
+        }
+
+        ClassIndex index = ClassIndex.build(Set.of(jarPath));
+
+        assertThat(index.getMatching("Or")).containsExactly("com.acme.Order");
+        assertThat(index.getMatching("Prod")).containsExactly("com.acme.Product");
+        assertThat(index.getMatching("Order$")).isEmpty();
+    }
+
+    @Test
+    void mixedSourcesAndPrefixMatching() throws IOException {
+        Path classesDir = tempDir.resolve("classes");
+        Path personClass = classesDir.resolve("org/example/Person.class");
+        Files.createDirectories(personClass.getParent());
+        Files.createFile(personClass);
+
+        Path jarPath = tempDir.resolve("security.jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new java.util.jar.JarEntry("java/security/Permission.class"));
+            jos.closeEntry();
+        }
+
+        ClassIndex index = ClassIndex.build(Set.of(classesDir, jarPath));
+
+        assertThat(index.getMatching("Per"))
+            .containsExactlyInAnyOrder("org.example.Person", "java.security.Permission");
+        assertThat(index.size()).isEqualTo(2);
+        assertThat(index.getMatching("Xyz")).isEmpty();
+    }
+
+    @Test
+    void emptyIndex() {
+        ClassIndex index = ClassIndex.empty();
+        assertThat(index.getMatching("Any")).isEmpty();
+        assertThat(index.size()).isEqualTo(0);
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -1,10 +1,16 @@
 package org.drools.completion;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
@@ -119,6 +125,95 @@ class DRLCompletionHelperTest {
         caretPosition.setCharacter(0);
         result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
         assertThat(completionItemStrings(result)).contains("import", "global", "rule"); // top level statements
+    }
+
+    @Test
+    void classCompletionInPatternPosition() throws IOException {
+        Path tempDir = Files.createTempDirectory("drools-test-classes");
+        try {
+            Files.createDirectories(tempDir.resolve("org/example"));
+            Files.createFile(tempDir.resolve("org/example/Person.class"));
+            Files.createFile(tempDir.resolve("org/example/Pet.class"));
+            Files.createFile(tempDir.resolve("org/example/Address.class"));
+
+            ClassIndex classIndex = ClassIndex.build(Set.of(tempDir));
+
+            String text = """
+                    package org.example;
+
+                    import org.example.Person;
+
+                    rule MyRule
+                      when
+                        $p : \s
+                      then
+                    end
+                    """;
+
+            Position caretPosition = new Position(6, 8);
+            List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient(), classIndex);
+
+            List<String> labels = result.stream().map(CompletionItem::getLabel).toList();
+            assertThat(labels).contains("Person", "Pet", "Address");
+
+            List<CompletionItem> classItems = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Class)
+                .toList();
+            assertThat(classItems).isNotEmpty();
+
+            CompletionItem personItem = classItems.stream()
+                .filter(item -> item.getLabel().equals("Person")).findFirst().orElseThrow();
+            CompletionItem addressItem = classItems.stream()
+                .filter(item -> item.getLabel().equals("Address")).findFirst().orElseThrow();
+
+            // Person is imported, so should sort before Address
+            assertThat(personItem.getSortText().compareTo(addressItem.getSortText())).isLessThan(0);
+        } finally {
+            try (var walk = Files.walk(tempDir)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try { Files.delete(p); } catch (IOException ignored) {}
+                });
+            }
+        }
+    }
+
+    @Test
+    void classCompletionWithTypedPrefix() throws IOException {
+        Path tempDir = Files.createTempDirectory("drools-test-classes");
+        try {
+            Files.createDirectories(tempDir.resolve("org/example"));
+            Files.createFile(tempDir.resolve("org/example/Person.class"));
+            Files.createFile(tempDir.resolve("org/example/Pet.class"));
+            Files.createFile(tempDir.resolve("org/example/Address.class"));
+
+            ClassIndex classIndex = ClassIndex.build(Set.of(tempDir));
+
+            String text = """
+                    package org.example;
+
+                    rule MyRule
+                      when
+                        $p : Per
+                      then
+                    end
+                    """;
+
+            Position caretPosition = new Position(4, 12);
+            List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient(), classIndex);
+
+            List<String> classLabels = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Class)
+                .map(CompletionItem::getLabel)
+                .toList();
+
+            assertThat(classLabels).contains("Person", "Pet", "Address");
+        } finally {
+            try (var walk = Files.walk(tempDir)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try { Files.delete(p); } catch (IOException ignored) {}
+                });
+            }
+        }
     }
 
     private List<String> completionItemStrings(List<CompletionItem> result) {

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -206,7 +206,8 @@ class DRLCompletionHelperTest {
                 .map(CompletionItem::getLabel)
                 .toList();
 
-            assertThat(classLabels).contains("Person", "Pet", "Address");
+            assertThat(classLabels).containsExactly("Person");
+            assertThat(classLabels).doesNotContain("Pet", "Address");
         } finally {
             try (var walk = Files.walk(tempDir)) {
                 walk.sorted(Comparator.reverseOrder()).forEach(p -> {

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/BuildOutputLocator.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/BuildOutputLocator.java
@@ -1,0 +1,124 @@
+package org.drools.lsp.server;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+/**
+ * Locates a module's compiled-output directories using filesystem conventions
+ * only -- no build tool is invoked and no extra dependencies are required.
+ *
+ * <p>This lets class indexing pick up the project's own compiled classes even
+ * when {@code mvn} is not available on the {@code PATH}, and copes with
+ * non-standard or non-Maven build layouts (Gradle, IDE output dirs, custom
+ * output roots).
+ *
+ * <p>Dependency JARs are out of scope here -- those are resolved separately by
+ * {@link MavenClasspathResolver}.
+ */
+public class BuildOutputLocator {
+
+    private static final Logger logger = Logger.getLogger(BuildOutputLocator.class.getName());
+
+    /** Conventional output directories, relative to a module root, in priority order. */
+    private static final List<String> CONVENTIONAL_OUTPUT_DIRS = List.of(
+        "target/classes",            // Maven (main)
+        "target/test-classes",       // Maven (test)
+        "build/classes/java/main",   // Gradle (main)
+        "build/classes/java/test",   // Gradle (test)
+        "out/production/classes",    // IntelliJ
+        "bin/main",                  // Eclipse / Buildship
+        "bin"                        // Eclipse (classic)
+    );
+
+    /** Subdirectory names that mark a build-tool intermediate rather than a package root. */
+    private static final Set<String> LANGUAGE_SUBDIRS = Set.of("java", "kotlin", "groovy", "scala");
+
+    /** Maximum depth, relative to the module root, for the fallback scan. */
+    private static final int MAX_FALLBACK_DEPTH = 8;
+
+    private BuildOutputLocator() {
+    }
+
+    /**
+     * Returns the existing compiled-output directories for {@code moduleDir},
+     * de-duplicated and in priority order.
+     *
+     * <p>Conventional locations are probed first. Only if none exist does a
+     * bounded scan look for a custom output root: a directory named
+     * {@code classes} that actually contains compiled output. Arbitrary custom
+     * output directory names cannot be detected without reading build metadata,
+     * which is intentionally out of scope for this dependency-free locator.
+     */
+    public static List<Path> findClassDirs(Path moduleDir) {
+        Set<Path> dirs = new LinkedHashSet<>();
+
+        for (String relative : CONVENTIONAL_OUTPUT_DIRS) {
+            Path candidate = moduleDir.resolve(relative);
+            if (Files.isDirectory(candidate)) {
+                dirs.add(candidate.normalize());
+            }
+        }
+
+        if (dirs.isEmpty()) {
+            dirs.addAll(scanForClassDirs(moduleDir));
+        }
+
+        return new ArrayList<>(dirs);
+    }
+
+    private static Set<Path> scanForClassDirs(Path moduleDir) {
+        Set<Path> found = new LinkedHashSet<>();
+        try {
+            Files.walkFileTree(moduleDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    Path name = dir.getFileName();
+                    String dirName = name == null ? "" : name.toString();
+
+                    if (dirName.startsWith(".") || dirName.equals("src") || dirName.equals("node_modules")) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    if (moduleDir.relativize(dir).getNameCount() > MAX_FALLBACK_DEPTH) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    if (dirName.equals("classes") && !hasLanguageSubdir(dir) && containsClassFile(dir)) {
+                        found.add(dir.normalize());
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to scan for class directories under " + moduleDir, e);
+        }
+        return found;
+    }
+
+    private static boolean hasLanguageSubdir(Path dir) {
+        try (Stream<Path> children = Files.list(dir)) {
+            return children.anyMatch(p -> Files.isDirectory(p)
+                && LANGUAGE_SUBDIRS.contains(p.getFileName().toString()));
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static boolean containsClassFile(Path dir) {
+        try (Stream<Path> walk = Files.walk(dir)) {
+            return walk.anyMatch(p -> p.toString().endsWith(".class") && Files.isRegularFile(p));
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
@@ -40,6 +40,10 @@ public class DroolsLspDocumentService implements TextDocumentService {
         this.classIndex = classIndex;
     }
 
+    ClassIndex getClassIndexForTest() {
+        return classIndex;
+    }
+
     @Override
     public void didOpen(DidOpenTextDocumentParams params) {
         sourcesMap.put(params.getTextDocument().getUri(), params.getTextDocument().getText());

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
@@ -11,6 +11,7 @@ import org.drools.completion.ClassIndex;
 import org.drools.completion.DRLCompletionHelper;
 import org.drools.drl.parser.antlr4.DRLParserHelper;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Diagnostic;
@@ -78,7 +79,14 @@ public class DroolsLspDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams completionParams) {
-        return CompletableFuture.supplyAsync(() -> Either.forLeft(attempt(() -> getCompletionItems(completionParams))));
+        return CompletableFuture.supplyAsync(() -> {
+            List<CompletionItem> items = attempt(() -> getCompletionItems(completionParams));
+            if (items == null) {
+                items = List.of();
+            }
+            boolean isIncomplete = items.stream().anyMatch(item -> item.getKind() == CompletionItemKind.Class);
+            return Either.forRight(new CompletionList(isIncomplete, items));
+        });
     }
 
     private <T> T attempt(Supplier<T> supplier) {

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import org.drools.completion.ClassIndex;
 import org.drools.completion.DRLCompletionHelper;
 import org.drools.drl.parser.antlr4.DRLParserHelper;
 import org.eclipse.lsp4j.CompletionItem;
@@ -27,11 +28,16 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 public class DroolsLspDocumentService implements TextDocumentService {
 
     private final Map<String, String> sourcesMap = new ConcurrentHashMap<>();
+    private volatile ClassIndex classIndex = ClassIndex.empty();
 
     private final DroolsLspServer server;
 
     public DroolsLspDocumentService(DroolsLspServer server) {
         this.server = server;
+    }
+
+    public void setClassIndex(ClassIndex classIndex) {
+        this.classIndex = classIndex;
     }
 
     @Override
@@ -84,7 +90,7 @@ public class DroolsLspDocumentService implements TextDocumentService {
         String text = sourcesMap.get(completionParams.getTextDocument().getUri());
 
         Position caretPosition = completionParams.getPosition();
-        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient());
+        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient(), classIndex);
 
         server.getClient().showMessage(new MessageParams(MessageType.Info, "Position=" + caretPosition));
         server.getClient().showMessage(new MessageParams(MessageType.Info, "completionItems = " + completionItems));

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -5,6 +5,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.drools.completion.ClassIndex;
 import org.eclipse.lsp4j.CompletionOptions;
@@ -18,6 +20,8 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 public class DroolsLspServer implements LanguageServer, LanguageClientAware {
+
+    private static final Logger logger = Logger.getLogger(DroolsLspServer.class.getName());
 
     private final DroolsLspDocumentService textService;
     private final WorkspaceService workspaceService;
@@ -42,6 +46,23 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
 
     public Set<Path> getClasspathEntries() {
         return classpathEntries;
+    }
+
+    public void rebuildClassIndex() {
+        Set<Path> entries = classpathEntries;
+        if (entries.isEmpty()) {
+            return;
+        }
+        try {
+            ClassIndex classIndex = ClassIndex.build(entries);
+            textService.setClassIndex(classIndex);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Failed to rebuild class index", e);
+        }
+    }
+
+    void setClasspathEntriesForTest(Set<Path> entries) {
+        this.classpathEntries = entries;
     }
 
     @Override

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -76,11 +76,15 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         String rootUri = params.getRootUri();
         if (rootUri != null) {
             CompletableFuture.runAsync(() -> {
-                Path rootPath = Paths.get(URI.create(rootUri));
-                Set<Path> resolved = MavenClasspathResolver.resolve(rootPath);
-                classpathEntries = resolved;
-                ClassIndex classIndex = ClassIndex.build(resolved);
-                textService.setClassIndex(classIndex);
+                try {
+                    Path rootPath = Paths.get(URI.create(rootUri));
+                    Set<Path> resolved = MavenClasspathResolver.resolve(rootPath);
+                    classpathEntries = resolved;
+                    ClassIndex classIndex = ClassIndex.build(resolved);
+                    textService.setClassIndex(classIndex);
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Failed to build class index at startup", e);
+                }
             });
         }
 

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -31,7 +31,7 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
 
     public DroolsLspServer() {
         textService = new DroolsLspDocumentService(this);
-        workspaceService = new DroolsLspWorkspaceService();
+        workspaceService = new DroolsLspWorkspaceService(this);
     }
 
 

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -1,8 +1,10 @@
 package org.drools.lsp.server;
 
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
@@ -28,6 +30,8 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
 
     private LanguageClient client;
     private volatile Set<Path> classpathEntries = Set.of();
+    private volatile Set<Path> buildOutputDirs = Set.of();
+    private volatile ClassIndex jarClassIndex = ClassIndex.empty();
 
     public DroolsLspServer() {
         textService = new DroolsLspDocumentService(this);
@@ -49,20 +53,47 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
     }
 
     public void rebuildClassIndex() {
-        Set<Path> entries = classpathEntries;
-        if (entries.isEmpty()) {
+        Set<Path> dirs = buildOutputDirs;
+        if (dirs.isEmpty() && jarClassIndex.size() == 0) {
             return;
         }
         try {
-            ClassIndex classIndex = ClassIndex.build(entries);
-            textService.setClassIndex(classIndex);
+            ClassIndex outputIndex = ClassIndex.build(dirs);
+            textService.setClassIndex(ClassIndex.merge(jarClassIndex, outputIndex));
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to rebuild class index", e);
         }
     }
 
-    void setClasspathEntriesForTest(Set<Path> entries) {
+    private void setResolvedClasspath(Set<Path> entries) {
         this.classpathEntries = entries;
+        this.buildOutputDirs = filterDirectories(entries);
+        Set<Path> jars = filterJars(entries);
+        this.jarClassIndex = jars.isEmpty() ? ClassIndex.empty() : ClassIndex.build(jars);
+    }
+
+    void setClasspathEntriesForTest(Set<Path> entries) {
+        setResolvedClasspath(entries);
+    }
+
+    private static Set<Path> filterDirectories(Set<Path> entries) {
+        Set<Path> dirs = new LinkedHashSet<>();
+        for (Path entry : entries) {
+            if (Files.isDirectory(entry)) {
+                dirs.add(entry);
+            }
+        }
+        return dirs;
+    }
+
+    private static Set<Path> filterJars(Set<Path> entries) {
+        Set<Path> jars = new LinkedHashSet<>();
+        for (Path entry : entries) {
+            if (!Files.isDirectory(entry)) {
+                jars.add(entry);
+            }
+        }
+        return jars;
     }
 
     @Override
@@ -79,9 +110,9 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
                 try {
                     Path rootPath = Paths.get(URI.create(rootUri));
                     Set<Path> resolved = MavenClasspathResolver.resolve(rootPath);
-                    classpathEntries = resolved;
-                    ClassIndex classIndex = ClassIndex.build(resolved);
-                    textService.setClassIndex(classIndex);
+                    setResolvedClasspath(resolved);
+                    ClassIndex outputIndex = ClassIndex.build(buildOutputDirs);
+                    textService.setClassIndex(ClassIndex.merge(jarClassIndex, outputIndex));
                 } catch (Exception e) {
                     logger.log(Level.WARNING, "Failed to build class index at startup", e);
                 }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -1,7 +1,12 @@
 package org.drools.lsp.server;
 
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import org.drools.completion.ClassIndex;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -36,14 +41,23 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
 
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-        // Initialize the InitializeResult for this LS.
         final InitializeResult initializeResult = new InitializeResult(new ServerCapabilities());
 
-        // Set the capabilities of the LS to inform the client.
         initializeResult.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
         CompletionOptions completionOptions = new CompletionOptions();
         initializeResult.getCapabilities().setCompletionProvider(completionOptions);
-        return CompletableFuture.supplyAsync( () -> initializeResult );
+
+        String rootUri = params.getRootUri();
+        if (rootUri != null) {
+            CompletableFuture.runAsync(() -> {
+                Path rootPath = Paths.get(URI.create(rootUri));
+                Set<Path> classpathEntries = MavenClasspathResolver.resolve(rootPath);
+                ClassIndex classIndex = ClassIndex.build(classpathEntries);
+                textService.setClassIndex(classIndex);
+            });
+        }
+
+        return CompletableFuture.supplyAsync(() -> initializeResult);
     }
 
     @Override

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -23,6 +23,7 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
     private final WorkspaceService workspaceService;
 
     private LanguageClient client;
+    private volatile Set<Path> classpathEntries = Set.of();
 
     public DroolsLspServer() {
         textService = new DroolsLspDocumentService(this);
@@ -39,6 +40,10 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         return client;
     }
 
+    public Set<Path> getClasspathEntries() {
+        return classpathEntries;
+    }
+
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult initializeResult = new InitializeResult(new ServerCapabilities());
@@ -51,8 +56,9 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         if (rootUri != null) {
             CompletableFuture.runAsync(() -> {
                 Path rootPath = Paths.get(URI.create(rootUri));
-                Set<Path> classpathEntries = MavenClasspathResolver.resolve(rootPath);
-                ClassIndex classIndex = ClassIndex.build(classpathEntries);
+                Set<Path> resolved = MavenClasspathResolver.resolve(rootPath);
+                classpathEntries = resolved;
+                ClassIndex classIndex = ClassIndex.build(resolved);
                 textService.setClassIndex(classIndex);
             });
         }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspWorkspaceService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspWorkspaceService.java
@@ -5,13 +5,19 @@ import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 public class DroolsLspWorkspaceService implements WorkspaceService {
+
+    private final DroolsLspServer server;
+
+    DroolsLspWorkspaceService(DroolsLspServer server) {
+        this.server = server;
+    }
+
     @Override
     public void didChangeConfiguration(DidChangeConfigurationParams params) {
-
     }
 
     @Override
     public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-
+        server.rebuildClassIndex();
     }
 }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspWorkspaceService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspWorkspaceService.java
@@ -1,12 +1,26 @@
 package org.drools.lsp.server;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 public class DroolsLspWorkspaceService implements WorkspaceService {
 
+    static final long DEBOUNCE_DELAY_MS = 1000;
+
     private final DroolsLspServer server;
+    private final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "drools-lsp-rebuild");
+                t.setDaemon(true);
+                return t;
+            });
+    private volatile ScheduledFuture<?> pendingRebuild;
 
     DroolsLspWorkspaceService(DroolsLspServer server) {
         this.server = server;
@@ -18,6 +32,12 @@ public class DroolsLspWorkspaceService implements WorkspaceService {
 
     @Override
     public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-        server.rebuildClassIndex();
+        ScheduledFuture<?> existing = pendingRebuild;
+        if (existing != null) {
+            existing.cancel(false);
+        }
+        pendingRebuild = scheduler.schedule(
+                () -> server.rebuildClassIndex(),
+                DEBOUNCE_DELAY_MS, TimeUnit.MILLISECONDS);
     }
 }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -69,8 +69,9 @@ public class MavenClasspathResolver {
 
         Path cpFile = Files.createTempFile("drools-lsp-cp-", ".txt");
         try {
+            String mvnCommand = System.getProperty("os.name").toLowerCase().contains("win") ? "mvn.cmd" : "mvn";
             ProcessBuilder pb = new ProcessBuilder(
-                "mvn", "-f", moduleDir.resolve("pom.xml").toString(),
+                mvnCommand, "-f", moduleDir.resolve("pom.xml").toString(),
                 "dependency:build-classpath",
                 "-Dmdep.outputFile=" + cpFile.toAbsolutePath()
             );

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -92,8 +93,7 @@ public class MavenClasspathResolver {
 
             String cpContent = Files.readString(cpFile).trim();
             if (!cpContent.isEmpty()) {
-                String separator = System.getProperty("os.name").toLowerCase().contains("win") ? ";" : ":";
-                Arrays.stream(cpContent.split(separator))
+                Arrays.stream(cpContent.split(File.pathSeparator))
                     .map(String::trim)
                     .filter(s -> !s.isEmpty())
                     .map(Path::of)

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -69,7 +69,24 @@ public class MavenClasspathResolver {
     private static Set<Path> resolveModule(Path moduleDir) throws IOException, InterruptedException {
         Set<Path> entries = new LinkedHashSet<>();
 
-        Path cpFile = Files.createTempFile("drools-lsp-cp-", ".txt");
+        resolveDependencyClasspath(moduleDir, entries);
+
+        Path targetClasses = moduleDir.resolve("target/classes");
+        if (Files.isDirectory(targetClasses)) {
+            entries.add(targetClasses);
+        }
+
+        return entries;
+    }
+
+    private static void resolveDependencyClasspath(Path moduleDir, Set<Path> entries) {
+        Path cpFile;
+        try {
+            cpFile = Files.createTempFile("drools-lsp-cp-", ".txt");
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to create temp file for classpath resolution", e);
+            return;
+        }
         try {
             String mvnCommand = System.getProperty("os.name").toLowerCase().contains("win") ? "mvn.cmd" : "mvn";
             ProcessBuilder pb = new ProcessBuilder(
@@ -90,11 +107,11 @@ public class MavenClasspathResolver {
             if (!finished) {
                 process.destroyForcibly();
                 logger.warning("mvn dependency:build-classpath timed out for " + moduleDir);
-                return entries;
+                return;
             }
             if (process.exitValue() != 0) {
                 logger.warning("mvn dependency:build-classpath failed for " + moduleDir + " with exit code " + process.exitValue());
-                return entries;
+                return;
             }
 
             String cpContent = Files.readString(cpFile).trim();
@@ -105,15 +122,10 @@ public class MavenClasspathResolver {
                     .map(Path::of)
                     .forEach(entries::add);
             }
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Failed to resolve dependency classpath for " + moduleDir + ": " + e.getMessage());
         } finally {
-            Files.deleteIfExists(cpFile);
+            try { Files.deleteIfExists(cpFile); } catch (IOException ignored) {}
         }
-
-        Path targetClasses = moduleDir.resolve("target/classes");
-        if (Files.isDirectory(targetClasses)) {
-            entries.add(targetClasses);
-        }
-
-        return entries;
     }
 }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,9 +86,14 @@ public class MavenClasspathResolver {
                 }
             }
 
-            int exitCode = process.waitFor();
-            if (exitCode != 0) {
-                logger.warning("mvn dependency:build-classpath failed for " + moduleDir + " with exit code " + exitCode);
+            boolean finished = process.waitFor(60, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                logger.warning("mvn dependency:build-classpath timed out for " + moduleDir);
+                return entries;
+            }
+            if (process.exitValue() != 0) {
+                logger.warning("mvn dependency:build-classpath failed for " + moduleDir + " with exit code " + process.exitValue());
                 return entries;
             }
 

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -66,15 +66,17 @@ public class MavenClasspathResolver {
         return result;
     }
 
-    private static Set<Path> resolveModule(Path moduleDir) throws IOException, InterruptedException {
+    private static Set<Path> resolveModule(Path moduleDir) {
         Set<Path> entries = new LinkedHashSet<>();
 
-        resolveDependencyClasspath(moduleDir, entries);
+        // The module's own compiled output -- located via filesystem conventions,
+        // so this works even when mvn is unavailable and copes with non-standard
+        // build layouts.
+        entries.addAll(BuildOutputLocator.findClassDirs(moduleDir));
 
-        Path targetClasses = moduleDir.resolve("target/classes");
-        if (Files.isDirectory(targetClasses)) {
-            entries.add(targetClasses);
-        }
+        // Dependency JARs -- best-effort via mvn; skipped gracefully when mvn is
+        // absent, offline, or otherwise fails.
+        resolveDependencyClasspath(moduleDir, entries);
 
         return entries;
     }

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -1,0 +1,112 @@
+package org.drools.lsp.server;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class MavenClasspathResolver {
+
+    private static final Logger logger = Logger.getLogger(MavenClasspathResolver.class.getName());
+
+    public static Set<Path> resolve(Path rootDir) {
+        Set<Path> classpathEntries = new LinkedHashSet<>();
+        List<Path> pomFiles = findPomFiles(rootDir);
+
+        for (Path pom : pomFiles) {
+            Path moduleDir = pom.getParent();
+            try {
+                Set<Path> moduleCp = resolveModule(moduleDir);
+                classpathEntries.addAll(moduleCp);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Failed to resolve classpath for " + pom + ": " + e.getMessage());
+            }
+        }
+
+        return classpathEntries;
+    }
+
+    static List<Path> findPomFiles(Path rootDir) {
+        List<Path> result = new ArrayList<>();
+        try {
+            Files.walkFileTree(rootDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    String dirName = dir.getFileName().toString();
+                    if (dirName.equals("target") || dirName.startsWith(".")) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (file.getFileName().toString().equals("pom.xml")) {
+                        result.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to walk directory tree: " + rootDir, e);
+        }
+        return result;
+    }
+
+    private static Set<Path> resolveModule(Path moduleDir) throws IOException, InterruptedException {
+        Set<Path> entries = new LinkedHashSet<>();
+
+        Path cpFile = Files.createTempFile("drools-lsp-cp-", ".txt");
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                "mvn", "-f", moduleDir.resolve("pom.xml").toString(),
+                "dependency:build-classpath",
+                "-Dmdep.outputFile=" + cpFile.toAbsolutePath()
+            );
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                while (reader.readLine() != null) {
+                    // drain
+                }
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                logger.warning("mvn dependency:build-classpath failed for " + moduleDir + " with exit code " + exitCode);
+                return entries;
+            }
+
+            String cpContent = Files.readString(cpFile).trim();
+            if (!cpContent.isEmpty()) {
+                String separator = System.getProperty("os.name").toLowerCase().contains("win") ? ";" : ":";
+                Arrays.stream(cpContent.split(separator))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(Path::of)
+                    .forEach(entries::add);
+            }
+        } finally {
+            Files.deleteIfExists(cpFile);
+        }
+
+        Path targetClasses = moduleDir.resolve("target/classes");
+        if (Files.isDirectory(targetClasses)) {
+            entries.add(targetClasses);
+        }
+
+        return entries;
+    }
+}

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/BuildOutputLocatorTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/BuildOutputLocatorTest.java
@@ -1,0 +1,102 @@
+package org.drools.lsp.server;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BuildOutputLocatorTest {
+
+    @TempDir
+    Path moduleDir;
+
+    @Test
+    void findsMavenTargetClasses() throws IOException {
+        Path classes = createDirWithClass(moduleDir.resolve("target/classes"), "com/example/Foo.class");
+        // a source directory must never be reported as compiled output
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).containsExactly(classes.normalize());
+    }
+
+    @Test
+    void findsMavenMainAndTestClasses() throws IOException {
+        Path main = createDirWithClass(moduleDir.resolve("target/classes"), "com/example/Foo.class");
+        Path test = createDirWithClass(moduleDir.resolve("target/test-classes"), "com/example/FooTest.class");
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).contains(main.normalize(), test.normalize());
+    }
+
+    @Test
+    void findsGradleOutput() throws IOException {
+        Path gradle = createDirWithClass(moduleDir.resolve("build/classes/java/main"), "com/example/Foo.class");
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).contains(gradle.normalize());
+    }
+
+    @Test
+    void prefersConventionalOverFallbackScan() throws IOException {
+        Path conventional = createDirWithClass(moduleDir.resolve("target/classes"), "com/example/Foo.class");
+        // a stray custom 'classes' dir that must be ignored because a conventional dir exists
+        createDirWithClass(moduleDir.resolve("custom-out/classes"), "com/other/Bar.class");
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).containsExactly(conventional.normalize());
+    }
+
+    @Test
+    void fallbackFindsCustomClassesDir() throws IOException {
+        Path custom = createDirWithClass(moduleDir.resolve("custom-out/classes"), "com/example/Foo.class");
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).containsExactly(custom.normalize());
+    }
+
+    @Test
+    void fallbackIgnoresEmptyClassesDir() throws IOException {
+        // a 'classes' dir with no .class files beneath it must not be reported
+        Files.createDirectories(moduleDir.resolve("weird/classes/empty"));
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).isEmpty();
+    }
+
+    @Test
+    void fallbackIgnoresGradleIntermediateClassesDir() throws IOException {
+        // 'build/classes' is a build-tool intermediate (has a 'java' subdir), not a
+        // package root -- it must not be reported as a class directory itself.
+        createDirWithClass(moduleDir.resolve("build/classes/java/custom"), "com/example/Foo.class");
+
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).noneMatch(p -> p.endsWith("build/classes") || p.endsWith(Path.of("build", "classes")));
+    }
+
+    @Test
+    void returnsEmptyWhenNoOutput() {
+        List<Path> dirs = BuildOutputLocator.findClassDirs(moduleDir);
+
+        assertThat(dirs).isEmpty();
+    }
+
+    private static Path createDirWithClass(Path dir, String classFileRelative) throws IOException {
+        Path classFile = dir.resolve(classFileRelative);
+        Files.createDirectories(classFile.getParent());
+        Files.createFile(classFile);
+        return dir;
+    }
+}

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/ClassCompletionIntegrationTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/ClassCompletionIntegrationTest.java
@@ -1,0 +1,94 @@
+package org.drools.lsp.server;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.drools.completion.ClassIndex;
+import org.drools.completion.DRLCompletionHelper;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClassCompletionIntegrationTest {
+
+    private static ClassIndex classIndex;
+
+    @BeforeAll
+    static void resolveClasspath() {
+        Path projectRoot = Path.of(System.getProperty("user.dir")).getParent();
+        assertThat(Files.exists(projectRoot.resolve("pom.xml")))
+            .as("drools-lsp project root must be available")
+            .isTrue();
+
+        Set<Path> entries = MavenClasspathResolver.resolve(projectRoot);
+        classIndex = ClassIndex.build(entries);
+        assertThat(classIndex.size()).isGreaterThan(0);
+    }
+
+    @Test
+    void dependencyJarClassSuggestedInPatternPosition() {
+        String text = """
+                package org.example;
+
+                rule TestRule
+                  when
+                    $t : \s
+                  then
+                end
+                """;
+
+        Position caretPosition = new Position(4, 8);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+            text, caretPosition, null, classIndex);
+
+        List<CompletionItem> classItems = result.stream()
+            .filter(item -> item.getKind() == CompletionItemKind.Class)
+            .toList();
+
+        assertThat(classItems).isNotEmpty();
+
+        // antlr4-runtime JAR class should appear (via detail = FQCN)
+        assertThat(classItems.stream().map(CompletionItem::getDetail).toList())
+            .contains("org.antlr.v4.runtime.ANTLRFileStream");
+
+        CompletionItem item = classItems.stream()
+            .filter(i -> "org.antlr.v4.runtime.ANTLRFileStream".equals(i.getDetail()))
+            .findFirst().orElseThrow();
+        assertThat(item.getLabel()).isEqualTo("ANTLRFileStream");
+        // Not imported, so sortText should start with "1_"
+        assertThat(item.getSortText()).startsWith("1_");
+    }
+
+    @Test
+    void importedDependencyClassRankedFirst() {
+        String text = """
+                package org.example;
+
+                import org.antlr.v4.runtime.ANTLRFileStream;
+
+                rule TestRule
+                  when
+                    $t : \s
+                  then
+                end
+                """;
+
+        Position caretPosition = new Position(6, 8);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+            text, caretPosition, null, classIndex);
+
+        CompletionItem item = result.stream()
+            .filter(i -> i.getKind() == CompletionItemKind.Class)
+            .filter(i -> "org.antlr.v4.runtime.ANTLRFileStream".equals(i.getDetail()))
+            .findFirst().orElseThrow();
+
+        // Imported, so sortText should start with "0_"
+        assertThat(item.getSortText()).startsWith("0_");
+    }
+}

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -1,8 +1,11 @@
 package org.drools.lsp.server;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
+import org.drools.completion.ClassIndex;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,5 +16,30 @@ class DroolsLspServerTest {
     void classpathEntriesRetainedAfterInitialize() {
         DroolsLspServer server = new DroolsLspServer();
         assertThat(server.getClasspathEntries()).isEmpty();
+    }
+
+    @Test
+    void rebuildClassIndexUpdatesDocumentService() {
+        DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
+
+        Path tempDir = createTempClassDir("com/example/Foo.class");
+        server.setClasspathEntriesForTest(Set.of(tempDir));
+
+        server.rebuildClassIndex();
+
+        ClassIndex index = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(index.getMatching("Foo")).contains("com.example.Foo");
+    }
+
+    private Path createTempClassDir(String classFilePath) {
+        try {
+            Path tempDir = Files.createTempDirectory("classindex-test");
+            Path classFile = tempDir.resolve(classFilePath);
+            Files.createDirectories(classFile.getParent());
+            Files.createFile(classFile);
+            return tempDir;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -8,23 +8,27 @@ import java.util.Set;
 import org.drools.completion.ClassIndex;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DroolsLspServerTest {
 
+    @TempDir
+    Path tempDir;
+
     @Test
-    void classpathEntriesRetainedAfterInitialize() {
+    void classpathEntriesEmptyBeforeInitialize() {
         DroolsLspServer server = new DroolsLspServer();
         assertThat(server.getClasspathEntries()).isEmpty();
     }
 
     @Test
-    void rebuildClassIndexUpdatesDocumentService() {
+    void rebuildClassIndexUpdatesDocumentService() throws IOException {
         DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
 
-        Path tempDir = createTempClassDir("com/example/Foo.class");
-        server.setClasspathEntriesForTest(Set.of(tempDir));
+        Path classDir = createClassDir("com/example/Foo.class");
+        server.setClasspathEntriesForTest(Set.of(classDir));
 
         server.rebuildClassIndex();
 
@@ -33,11 +37,11 @@ class DroolsLspServerTest {
     }
 
     @Test
-    void didChangeWatchedFilesTriggersRebuild() {
+    void didChangeWatchedFilesTriggersRebuild() throws IOException {
         DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
 
-        Path tempDir = createTempClassDir("com/example/Bar.class");
-        server.setClasspathEntriesForTest(Set.of(tempDir));
+        Path classDir = createClassDir("com/example/Bar.class");
+        server.setClasspathEntriesForTest(Set.of(classDir));
 
         DroolsLspWorkspaceService workspaceService = (DroolsLspWorkspaceService) server.getWorkspaceService();
         workspaceService.didChangeWatchedFiles(new DidChangeWatchedFilesParams());
@@ -46,15 +50,10 @@ class DroolsLspServerTest {
         assertThat(index.getMatching("Bar")).contains("com.example.Bar");
     }
 
-    private Path createTempClassDir(String classFilePath) {
-        try {
-            Path tempDir = Files.createTempDirectory("classindex-test");
-            Path classFile = tempDir.resolve(classFilePath);
-            Files.createDirectories(classFile.getParent());
-            Files.createFile(classFile);
-            return tempDir;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    private Path createClassDir(String classFilePath) throws IOException {
+        Path classFile = tempDir.resolve(classFilePath);
+        Files.createDirectories(classFile.getParent());
+        Files.createFile(classFile);
+        return tempDir;
     }
 }

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -37,7 +37,7 @@ class DroolsLspServerTest {
     }
 
     @Test
-    void didChangeWatchedFilesTriggersRebuild() throws IOException {
+    void didChangeWatchedFilesTriggersRebuild() throws Exception {
         DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
 
         Path classDir = createClassDir("com/example/Bar.class");
@@ -46,8 +46,33 @@ class DroolsLspServerTest {
         DroolsLspWorkspaceService workspaceService = (DroolsLspWorkspaceService) server.getWorkspaceService();
         workspaceService.didChangeWatchedFiles(new DidChangeWatchedFilesParams());
 
+        Thread.sleep(DroolsLspWorkspaceService.DEBOUNCE_DELAY_MS + 500);
+
         ClassIndex index = server.getTextDocumentService().getClassIndexForTest();
         assertThat(index.getMatching("Bar")).contains("com.example.Bar");
+    }
+
+    @Test
+    void rapidFileChangesCoalesceIntoOneRebuild() throws Exception {
+        DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
+
+        Path classDir = createClassDir("com/example/Baz.class");
+        server.setClasspathEntriesForTest(Set.of(classDir));
+
+        DroolsLspWorkspaceService workspaceService = (DroolsLspWorkspaceService) server.getWorkspaceService();
+        for (int i = 0; i < 100; i++) {
+            workspaceService.didChangeWatchedFiles(new DidChangeWatchedFilesParams());
+        }
+
+        // Index should not be rebuilt yet (still within debounce window)
+        ClassIndex indexBefore = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(indexBefore.getMatching("Baz")).isEmpty();
+
+        Thread.sleep(DroolsLspWorkspaceService.DEBOUNCE_DELAY_MS + 500);
+
+        ClassIndex indexAfter = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(indexAfter).isNotNull();
+        assertThat(indexAfter.getMatching("Baz")).contains("com.example.Baz");
     }
 
     private Path createClassDir(String classFilePath) throws IOException {

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.Set;
 
 import org.drools.completion.ClassIndex;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +30,20 @@ class DroolsLspServerTest {
 
         ClassIndex index = server.getTextDocumentService().getClassIndexForTest();
         assertThat(index.getMatching("Foo")).contains("com.example.Foo");
+    }
+
+    @Test
+    void didChangeWatchedFilesTriggersRebuild() {
+        DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
+
+        Path tempDir = createTempClassDir("com/example/Bar.class");
+        server.setClasspathEntriesForTest(Set.of(tempDir));
+
+        DroolsLspWorkspaceService workspaceService = (DroolsLspWorkspaceService) server.getWorkspaceService();
+        workspaceService.didChangeWatchedFiles(new DidChangeWatchedFilesParams());
+
+        ClassIndex index = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(index.getMatching("Bar")).contains("com.example.Bar");
     }
 
     private Path createTempClassDir(String classFilePath) {

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -1,0 +1,17 @@
+package org.drools.lsp.server;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DroolsLspServerTest {
+
+    @Test
+    void classpathEntriesRetainedAfterInitialize() {
+        DroolsLspServer server = new DroolsLspServer();
+        assertThat(server.getClasspathEntries()).isEmpty();
+    }
+}

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspServerTest.java
@@ -75,6 +75,37 @@ class DroolsLspServerTest {
         assertThat(indexAfter.getMatching("Baz")).contains("com.example.Baz");
     }
 
+    // Verifies the cached JAR index is used on rebuild, not that JARs are
+    // literally not re-read — the latter would require a spy on ClassIndex.build.
+    @Test
+    void rebuildPreservesJarClassesFromCachedIndex() throws Exception {
+        DroolsLspServer server = TestHelperMethods.getDroolsLspServerForDocument("");
+
+        Path classDir = createClassDir("com/example/Foo.class");
+
+        Path jarPath = tempDir.resolve("dep.jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new java.util.jar.JarEntry("com/acme/Order.class"));
+            jos.closeEntry();
+        }
+
+        server.setClasspathEntriesForTest(Set.of(classDir, jarPath));
+        server.rebuildClassIndex();
+
+        ClassIndex index = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(index.getMatching("Foo")).contains("com.example.Foo");
+        assertThat(index.getMatching("Or")).contains("com.acme.Order");
+
+        // Delete the JAR — rebuild should still have JAR classes from cached index
+        Files.delete(jarPath);
+        server.rebuildClassIndex();
+
+        ClassIndex indexAfter = server.getTextDocumentService().getClassIndexForTest();
+        assertThat(indexAfter.getMatching("Foo")).contains("com.example.Foo");
+        assertThat(indexAfter.getMatching("Or")).contains("com.acme.Order");
+    }
+
     private Path createClassDir(String classFilePath) throws IOException {
         Path classFile = tempDir.resolve(classFilePath);
         Files.createDirectories(classFile.getParent());

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/MavenClasspathResolverTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/MavenClasspathResolverTest.java
@@ -1,0 +1,57 @@
+package org.drools.lsp.server;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MavenClasspathResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void findPomFiles() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+
+        Path submodule = tempDir.resolve("module-a");
+        Files.createDirectories(submodule);
+        Files.writeString(submodule.resolve("pom.xml"), "<project/>");
+
+        // pom.xml inside target/ should be skipped
+        Path targetDir = tempDir.resolve("module-a/target/generated");
+        Files.createDirectories(targetDir);
+        Files.writeString(targetDir.resolve("pom.xml"), "<project/>");
+
+        // pom.xml inside hidden dir should be skipped
+        Path hiddenDir = tempDir.resolve(".hidden");
+        Files.createDirectories(hiddenDir);
+        Files.writeString(hiddenDir.resolve("pom.xml"), "<project/>");
+
+        List<Path> poms = MavenClasspathResolver.findPomFiles(tempDir);
+
+        assertThat(poms).containsExactlyInAnyOrder(
+            tempDir.resolve("pom.xml"),
+            submodule.resolve("pom.xml")
+        );
+    }
+
+    @Test
+    void resolveReturnsClasspathEntriesForRealProject() {
+        Path projectRoot = Path.of(System.getProperty("user.dir")).getParent();
+        if (!Files.exists(projectRoot.resolve("pom.xml"))) {
+            return;
+        }
+
+        Set<Path> entries = MavenClasspathResolver.resolve(projectRoot);
+
+        assertThat(entries).isNotEmpty();
+        assertThat(entries.stream().anyMatch(p -> p.toString().endsWith(".jar"))).isTrue();
+    }
+}


### PR DESCRIPTION
# Java Class Completion in DRL

## Class Name Completion in LHS Patterns

When writing a DRL rule's `when` clause, the LSP server now suggests Java class
names from the project's classpath in pattern positions.

```drl
rule "example"
  when
    $p : Per|    <-- suggests "Person", "PersistenceException", etc.
  then
end
```

https://github.com/user-attachments/assets/b9054589-7f70-4352-ad05-8616f5c52190

Imported classes are ranked above unimported ones in the completion list.

### How it works

1. At server startup, `MavenClasspathResolver` runs
   `mvn dependency:build-classpath` for each Maven module under the workspace
   root, collecting all dependency JARs and each module's `target/classes`
   directory.
2. `ClassIndex` scans those entries (walking directories, reading JAR manifests)
   to build a map of simple class name to fully-qualified class names.
3. When the completion engine detects the caret is in a pattern's object-type
   position (`objectType = drlQualifiedName` in `lhsPattern`), it queries the
   index for prefix matches.
4. Completion items show the simple name as the label and the FQCN as the
   detail. Imported classes sort first, unimported classes sort after.

## Live Index Refresh on Recompile

The class index updates automatically when the user recompiles their project --
no server restart required.

1. The VS Code client registers a `FileSystemWatcher` for
   `**/target/classes/**/*.class`.
2. When `.class` files are created, changed, or deleted, the LSP protocol sends
   a `workspace/didChangeWatchedFiles` notification to the server.
3. The server re-scans all retained classpath entries and atomically swaps in the
   new `ClassIndex` via a `volatile` field.
4. The next completion request uses the updated index.

If the rebuild fails (e.g., a JAR is temporarily locked), the previous index is
kept.

## Scope

### Included

- Maven classpath resolution (`mvn dependency:build-classpath` + `target/classes`)
- Class name scanning from directories and JARs
- Completion in LHS pattern positions
- Import-aware ranking
- Graceful fallback if `mvn` is not available
- Live refresh on `.class` file changes

### Not included

- RHS support
- Gradle support
- Method/field completion
- Auto-import on completion accept
- `declare` type completion (types defined in DRL)
- Re-running Maven on `pom.xml` changes (new dependencies)
- Debouncing rapid file change events
