### PR TITLE
feat/field completion inside pattern constraints

### DIFF
--- a/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
@@ -132,6 +132,10 @@ public final class ClassMemberIndex {
             }
             raw = name.substring(3);
         } else if (name.startsWith("is") && name.length() > 2 && Character.isUpperCase(name.charAt(2))) {
+            Class<?> returnType = m.getReturnType();
+            if (returnType != boolean.class && returnType != Boolean.class) {
+                return null;
+            }
             raw = name.substring(2);
         } else {
             return null;

--- a/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
@@ -1,0 +1,146 @@
+package org.drools.completion;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Lazily reflects the members of classes on the resolved project classpath
+ * (the same entries {@link ClassIndex} is built from), so completion can
+ * offer field and bean-property names for pattern types.
+ *
+ * <p>Classes are loaded with {@code Class.forName(fqcn, false, loader)} —
+ * <b>static initializers never run</b>, so member lookup cannot execute
+ * arbitrary user code inside the language server. The loader's parent is the
+ * platform class loader, so the server's own classes never leak into user
+ * completions. Results (including misses) are cached per FQCN.
+ */
+public final class ClassMemberIndex {
+
+    private static final Logger logger = Logger.getLogger(ClassMemberIndex.class.getName());
+
+    private static final ClassMemberIndex EMPTY = new ClassMemberIndex((ClassLoader) null);
+
+    private final ClassLoader loader;
+    private final Map<String, List<Field>> cache = new ConcurrentHashMap<>();
+
+    /** Visible for tests: reflect against an existing class loader. */
+    ClassMemberIndex(ClassLoader loader) {
+        this.loader = loader;
+    }
+
+    /** An index that resolves nothing. */
+    public static ClassMemberIndex empty() {
+        return EMPTY;
+    }
+
+    /** Builds an index over the given classpath entries (jars and class dirs). */
+    public static ClassMemberIndex of(Set<Path> classpathEntries) {
+        if (classpathEntries == null || classpathEntries.isEmpty()) {
+            return EMPTY;
+        }
+        List<URL> urls = new ArrayList<>(classpathEntries.size());
+        for (Path entry : classpathEntries) {
+            try {
+                urls.add(entry.toUri().toURL());
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Skipping classpath entry " + entry, e);
+            }
+        }
+        URLClassLoader loader = new URLClassLoader(
+                urls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader());
+        return new ClassMemberIndex(loader);
+    }
+
+    /**
+     * Returns the completable members of {@code fqcn}: enum constants, bean
+     * properties derived from public no-arg {@code getX()}/{@code isX()}
+     * methods (including inherited ones), and public instance fields. Empty
+     * when the class cannot be loaded.
+     */
+    public List<Field> membersOf(String fqcn) {
+        if (loader == null || fqcn == null || fqcn.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return cache.computeIfAbsent(fqcn, this::reflectMembers);
+    }
+
+    private List<Field> reflectMembers(String fqcn) {
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(fqcn, false, loader);
+        } catch (Throwable t) {
+            return Collections.emptyList();
+        }
+        try {
+            Map<String, Field> members = new LinkedHashMap<>();
+            if (clazz.isEnum()) {
+                for (java.lang.reflect.Field f : clazz.getFields()) {
+                    if (f.isEnumConstant()) {
+                        members.put(f.getName(),
+                                new Field(f.getName(), clazz.getSimpleName()));
+                    }
+                }
+            }
+            for (Method m : clazz.getMethods()) {
+                String property = propertyNameOf(m);
+                if (property != null) {
+                    members.putIfAbsent(property,
+                            new Field(property, m.getReturnType().getSimpleName()));
+                }
+            }
+            for (java.lang.reflect.Field f : clazz.getFields()) {
+                if (!Modifier.isStatic(f.getModifiers())) {
+                    members.putIfAbsent(f.getName(),
+                            new Field(f.getName(), f.getType().getSimpleName()));
+                }
+            }
+            return Collections.unmodifiableList(new ArrayList<>(members.values()));
+        } catch (Throwable t) {
+            // LinkageError etc. while reflecting — treat as unknown.
+            logger.log(Level.FINE, "Failed to reflect members of " + fqcn, t);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Maps a public no-arg {@code getX()}/{@code isX()} method to its bean
+     * property name (JavaBeans decapitalize rule), or returns {@code null}
+     * for non-accessors and {@code getClass()}.
+     */
+    private static String propertyNameOf(Method m) {
+        if (m.getParameterCount() != 0 || m.getReturnType() == void.class
+                || Modifier.isStatic(m.getModifiers())) {
+            return null;
+        }
+        String name = m.getName();
+        String raw;
+        if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {
+            if ("getClass".equals(name)) {
+                return null;
+            }
+            raw = name.substring(3);
+        } else if (name.startsWith("is") && name.length() > 2 && Character.isUpperCase(name.charAt(2))) {
+            raw = name.substring(2);
+        } else {
+            return null;
+        }
+        if (raw.length() > 1 && Character.isUpperCase(raw.charAt(0)) && Character.isUpperCase(raw.charAt(1))) {
+            return raw;
+        }
+        char[] chars = raw.toCharArray();
+        chars[0] = Character.toLowerCase(chars[0]);
+        return new String(chars);
+    }
+}

--- a/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
+++ b/drools-completion/src/main/java/org/drools/completion/ClassMemberIndex.java
@@ -26,18 +26,24 @@ import java.util.logging.Logger;
  * platform class loader, so the server's own classes never leak into user
  * completions. Results (including misses) are cached per FQCN.
  */
-public final class ClassMemberIndex {
+public final class ClassMemberIndex implements AutoCloseable {
 
     private static final Logger logger = Logger.getLogger(ClassMemberIndex.class.getName());
 
     private static final ClassMemberIndex EMPTY = new ClassMemberIndex((ClassLoader) null);
 
     private final ClassLoader loader;
+    private final boolean ownsLoader;
     private final Map<String, List<Field>> cache = new ConcurrentHashMap<>();
 
-    /** Visible for tests: reflect against an existing class loader. */
+    /** Visible for tests: reflect against an existing (externally-owned) loader. */
     ClassMemberIndex(ClassLoader loader) {
+        this(loader, false);
+    }
+
+    private ClassMemberIndex(ClassLoader loader, boolean ownsLoader) {
         this.loader = loader;
+        this.ownsLoader = ownsLoader;
     }
 
     /** An index that resolves nothing. */
@@ -60,7 +66,19 @@ public final class ClassMemberIndex {
         }
         URLClassLoader loader = new URLClassLoader(
                 urls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader());
-        return new ClassMemberIndex(loader);
+        return new ClassMemberIndex(loader, true);
+    }
+
+    @Override
+    public void close() {
+        cache.clear();
+        if (ownsLoader && loader instanceof java.io.Closeable closeable) {
+            try {
+                closeable.close();
+            } catch (java.io.IOException e) {
+                logger.log(Level.FINE, "Failed to close class member index loader", e);
+            }
+        }
     }
 
     /**

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -68,7 +68,12 @@ public class DRLCompletionHelper {
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
         String prefix = extractPrefix(drlParser, nodeIndex);
 
-        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix, memberIndex);
+        // null when the caret is past the last token; fall back to EOF.
+        int caretTokenIndex = nodeIndex != null
+                ? nodeIndex
+                : drlParser.getInputStream().size() - 1;
+
+        return getCompletionItems(drlParser, caretTokenIndex, compilationUnit, classIndex, prefix, memberIndex);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -23,7 +23,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.vmware.antlr4c3.CodeCompletionCore;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.drools.drl.parser.antlr4.DRL10Lexer;
 import org.drools.drl.parser.antlr4.DRL10Parser;
 import org.eclipse.lsp4j.CompletionItem;
@@ -53,6 +55,10 @@ public class DRLCompletionHelper {
     }
 
     public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client, ClassIndex classIndex) {
+        return getCompletionItems(text, caretPosition, client, classIndex, ClassMemberIndex.empty());
+    }
+
+    public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client, ClassIndex classIndex, ClassMemberIndex memberIndex) {
         DRL10Parser drlParser = createDrlParser(text);
 
         int row = caretPosition == null ? -1 : caretPosition.getLine() + 1; // caret line position is zero based
@@ -62,14 +68,14 @@ public class DRLCompletionHelper {
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
         String prefix = extractPrefix(drlParser, nodeIndex);
 
-        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix);
+        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix, memberIndex);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
-        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "");
+        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "", ClassMemberIndex.empty());
     }
 
-    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix) {
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix, ClassMemberIndex memberIndex) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -88,7 +94,110 @@ public class DRLCompletionHelper {
             items.addAll(getClassCompletionItems(compilationUnit, classIndex, prefix));
         }
 
+        if (compilationUnit != null && isConstraintPosition(candidates)) {
+            items.addAll(getFieldCompletionItems(compilationUnit, nodeIndex, classIndex, memberIndex));
+        }
+
         return items;
+    }
+
+    private static boolean isConstraintPosition(CodeCompletionCore.CandidatesCollection candidates) {
+        List<Integer> path = candidates.rules.get(DRL10Parser.RULE_drlIdentifier);
+        return path != null && path.contains(DRL10Parser.RULE_constraint);
+    }
+
+    /**
+     * Completion items for the fields of the pattern enclosing the caret:
+     * fields of a DRL-declared type in the same document, or bean
+     * properties/fields of a classpath type resolved through imports and the
+     * class index.
+     */
+    private static List<CompletionItem> getFieldCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit,
+                                                                int nodeIndex, ClassIndex classIndex,
+                                                                ClassMemberIndex memberIndex) {
+        String patternType = findEnclosingPatternTypeName(compilationUnit, nodeIndex);
+        if (patternType == null || patternType.isEmpty()) {
+            return List.of();
+        }
+        String simpleName = patternType.substring(patternType.lastIndexOf('.') + 1);
+
+        // DRL-declared types in the current document win over classpath types.
+        for (DeclaredType declared : DRLDeclaredTypeParser.extractFromCompilationUnit(compilationUnit)) {
+            if (simpleName.equals(declared.name)) {
+                return fieldItems(declared.fields);
+            }
+        }
+
+        String fqcn = resolveFqcn(patternType, simpleName, compilationUnit, classIndex);
+        if (fqcn == null) {
+            return List.of();
+        }
+        return fieldItems(memberIndex.membersOf(fqcn));
+    }
+
+    private static List<CompletionItem> fieldItems(List<Field> fields) {
+        List<CompletionItem> items = new ArrayList<>(fields.size());
+        for (Field field : fields) {
+            CompletionItem item = new CompletionItem();
+            item.setLabel(field.name);
+            item.setInsertText(field.name);
+            item.setDetail(field.type);
+            item.setKind(CompletionItemKind.Field);
+            items.add(item);
+        }
+        return items;
+    }
+
+    /**
+     * Resolves a pattern's type name to a fully qualified class name: an
+     * already-qualified name is used as-is, otherwise the imports and then
+     * the class index are consulted for the simple name.
+     */
+    private static String resolveFqcn(String patternType, String simpleName,
+                                      DRL10Parser.CompilationUnitContext compilationUnit,
+                                      ClassIndex classIndex) {
+        if (patternType.indexOf('.') >= 0) {
+            return patternType;
+        }
+        for (String imported : extractImports(compilationUnit)) {
+            if (imported.endsWith("." + simpleName)) {
+                return imported;
+            }
+        }
+        for (String fqcn : classIndex.getMatching(simpleName)) {
+            if (fqcn.endsWith("." + simpleName) || fqcn.equals(simpleName)) {
+                return fqcn;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the type name of the deepest {@code lhsPattern} whose token
+     * span contains {@code tokenIndex}, or {@code null} when the caret is
+     * not inside a pattern.
+     */
+    private static String findEnclosingPatternTypeName(ParseTree node, int tokenIndex) {
+        if (!(node instanceof ParserRuleContext ctx)) {
+            return null;
+        }
+        Token start = ctx.getStart();
+        Token stop = ctx.getStop();
+        if (start == null || start.getTokenIndex() > tokenIndex
+                || (stop != null && stop.getTokenIndex() < tokenIndex)) {
+            return null;
+        }
+        String best = null;
+        if (ctx instanceof DRL10Parser.LhsPatternContext pattern && pattern.objectType != null) {
+            best = pattern.objectType.getText();
+        }
+        for (int i = 0; i < ctx.getChildCount(); i++) {
+            String deeper = findEnclosingPatternTypeName(ctx.getChild(i), tokenIndex);
+            if (deeper != null) {
+                best = deeper;
+            }
+        }
+        return best;
     }
 
     private static boolean isPatternPosition(CodeCompletionCore.CandidatesCollection candidates) {

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vmware.antlr4c3.CodeCompletionCore;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -46,6 +47,26 @@ public class DRLCompletionHelper {
             DRL10Parser.RULE_stringId,
             DRL10Parser.RULE_consequenceBody
     );
+
+    // The eight Java primitive-type keyword tokens. Mirrors the grammar's
+    // `primitiveType` rule (DRL10Expressions.g4), which shares DRL10Lexer's token
+    // vocab — so these ids match the ones c3 reports against DRL10Parser. ANTLR
+    // exposes no token-set constant for a rule, so the list is restated here.
+    private static final Set<Integer> PRIMITIVE_TYPE_TOKENS = Set.of(
+            DRL10Parser.BOOLEAN, DRL10Parser.CHAR, DRL10Parser.BYTE, DRL10Parser.SHORT,
+            DRL10Parser.INT, DRL10Parser.LONG, DRL10Parser.FLOAT, DRL10Parser.DOUBLE
+    );
+
+    // Inside a pattern constraint, c3 predicts the Java expression starters that
+    // can legally open a constraint: the primitive types above plus new/super and
+    // the big-decimal/-integer literal tokens. They are valid grammar but useless
+    // noise next to the field completions, so they are dropped in constraint
+    // position only — primitive types stay useful elsewhere (e.g. after `global`).
+    private static final Set<Integer> CONSTRAINT_KEYWORD_NOISE = Stream.concat(
+            PRIMITIVE_TYPE_TOKENS.stream(),
+            Stream.of(DRL10Parser.NEW, DRL10Parser.SUPER,
+                    DRL10Parser.DRL_BIG_DECIMAL_LITERAL, DRL10Parser.DRL_BIG_INTEGER_LITERAL)
+    ).collect(Collectors.toUnmodifiableSet());
 
     private DRLCompletionHelper() {
     }
@@ -99,7 +120,10 @@ public class DRLCompletionHelper {
             candidates.tokens.put(DRL10Lexer.DRL_RHS_END, List.of());
         }
 
+        boolean constraintPosition = compilationUnit != null && isConstraintPosition(candidates);
+
         List<CompletionItem> items = candidates.tokens.keySet().stream().filter(Objects::nonNull)
+                .filter(token -> !(constraintPosition && CONSTRAINT_KEYWORD_NOISE.contains(token)))
                 .map(integer -> drlParser.getVocabulary().getDisplayName(integer).replace("'", ""))
                 .map(String::toLowerCase)
                 .map(k -> createCompletionItem(k, CompletionItemKind.Keyword))
@@ -109,7 +133,7 @@ public class DRLCompletionHelper {
             items.addAll(getClassCompletionItems(compilationUnit, classIndex, prefix));
         }
 
-        if (compilationUnit != null && isConstraintPosition(candidates)) {
+        if (constraintPosition) {
             items.addAll(getFieldCompletionItems(compilationUnit, patternTokenIndex, classIndex, memberIndex));
         }
 

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -73,14 +73,24 @@ public class DRLCompletionHelper {
                 ? nodeIndex
                 : drlParser.getInputStream().size() - 1;
 
-        return getCompletionItems(drlParser, caretTokenIndex, compilationUnit, classIndex, prefix, memberIndex);
+        // Right after '(' the matched token is the paren itself, for which c3
+        // yields no candidates; look one token ahead for the constraint, but
+        // keep the paren's index to resolve the pattern type (its span ends at
+        // '(' until the closing ')' is typed).
+        int candidatesIndex = caretTokenIndex;
+        if (caretTokenIndex >= 0 && caretTokenIndex < drlParser.getInputStream().size() - 1
+                && drlParser.getInputStream().get(caretTokenIndex).getType() == DRL10Lexer.LPAREN) {
+            candidatesIndex = caretTokenIndex + 1;
+        }
+
+        return getCompletionItems(drlParser, candidatesIndex, caretTokenIndex, compilationUnit, classIndex, prefix, memberIndex);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
-        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "", ClassMemberIndex.empty());
+        return getCompletionItems(drlParser, nodeIndex, nodeIndex, null, ClassIndex.empty(), "", ClassMemberIndex.empty());
     }
 
-    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix, ClassMemberIndex memberIndex) {
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, int patternTokenIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix, ClassMemberIndex memberIndex) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -100,7 +110,7 @@ public class DRLCompletionHelper {
         }
 
         if (compilationUnit != null && isConstraintPosition(candidates)) {
-            items.addAll(getFieldCompletionItems(compilationUnit, nodeIndex, classIndex, memberIndex));
+            items.addAll(getFieldCompletionItems(compilationUnit, patternTokenIndex, classIndex, memberIndex));
         }
 
         return items;

--- a/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -1,0 +1,176 @@
+package org.drools.completion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.drools.drl.parser.antlr4.DRL10Parser;
+import org.drools.drl.parser.antlr4.DRLParserHelper;
+
+/**
+ * Extracts {@link DeclaredType}s ({@code declare} blocks, including declared
+ * enums) from DRL source using the ANTLR parser, so completion can offer the
+ * fields of types that exist only in DRL and never on the compiled classpath.
+ */
+public final class DRLDeclaredTypeParser {
+
+    private static final Logger logger =
+            Logger.getLogger(DRLDeclaredTypeParser.class.getName());
+
+    /** Swallows ANTLR parse errors — partial/incomplete DRL is normal here. */
+    private static final BaseErrorListener SILENT = new BaseErrorListener() {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg,
+                                RecognitionException e) {
+        }
+    };
+
+    private DRLDeclaredTypeParser() {
+    }
+
+    /**
+     * Parses all {@code declare} blocks in {@code text}. Parser errors are
+     * ignored so partial files still yield partial results.
+     */
+    public static List<DeclaredType> parseDeclaredTypes(String text) {
+        List<DeclaredType> types = new ArrayList<>();
+        if (text == null || text.isBlank()) {
+            return types;
+        }
+        try {
+            DRL10Parser parser = DRLParserHelper.createDrlParser(text);
+            Lexer lexer = (Lexer) parser.getTokenStream().getTokenSource();
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(SILENT);
+            parser.removeErrorListeners();
+            parser.addErrorListener(SILENT);
+            return extractFromCompilationUnit(parser.compilationUnit());
+        } catch (Exception e) {
+            logger.fine(() -> "Failed to parse DRL for declared types: " + e.getMessage());
+        }
+        return types;
+    }
+
+    /**
+     * Extracts declared types from an already-parsed compilation unit. Use
+     * this overload when the caller already produced the parse tree (e.g.
+     * during completion) to avoid a redundant second parse.
+     */
+    static List<DeclaredType> extractFromCompilationUnit(DRL10Parser.CompilationUnitContext cu) {
+        List<DeclaredType> types = new ArrayList<>();
+        if (cu == null) {
+            return types;
+        }
+        for (DRL10Parser.DrlStatementdefContext stmt : cu.drlStatementdef()) {
+            DRL10Parser.DeclaredefContext decl = stmt.declaredef();
+            if (decl == null) {
+                continue;
+            }
+            try {
+                if (decl.typeDeclaration() != null) {
+                    DeclaredType dt = extractTypeDeclaration(decl.typeDeclaration());
+                    if (dt != null) {
+                        types.add(dt);
+                    }
+                } else if (decl.enumDeclaration() != null) {
+                    DeclaredType dt = extractEnumDeclaration(decl.enumDeclaration());
+                    if (dt != null) {
+                        types.add(dt);
+                    }
+                }
+                // entryPointDeclaration and windowDeclaration are not class types.
+            } catch (Exception e) {
+                logger.fine(() -> "Skipping malformed declare block: " + e.getMessage());
+            }
+        }
+        return types;
+    }
+
+    private static DeclaredType extractTypeDeclaration(DRL10Parser.TypeDeclarationContext ctx) {
+        if (ctx == null || ctx.name == null) {
+            return null;
+        }
+        String name = ctx.name.getText();
+        int nameLine = ctx.name.getStart() != null ? ctx.name.getStart().getLine() - 1 : 0;
+        int nameCol = ctx.name.getStart() != null ? ctx.name.getStart().getCharPositionInLine() : 0;
+        List<Field> fields = extractFields(ctx.field());
+        String extendsName = null;
+        if (ctx.superTypes != null && !ctx.superTypes.isEmpty()) {
+            String raw = ctx.superTypes.get(0).getText();
+            int dot = raw == null ? -1 : raw.lastIndexOf('.');
+            extendsName = (raw != null && dot >= 0) ? raw.substring(dot + 1) : raw;
+        }
+        return new DeclaredType(name, fields, false, nameLine, nameCol, extendsName);
+    }
+
+    private static DeclaredType extractEnumDeclaration(DRL10Parser.EnumDeclarationContext ctx) {
+        if (ctx == null || ctx.name == null) {
+            return null;
+        }
+        String name = ctx.name.getText();
+        int nameLine = ctx.name.getStart() != null ? ctx.name.getStart().getLine() - 1 : 0;
+        int nameCol = ctx.name.getStart() != null ? ctx.name.getStart().getCharPositionInLine() : 0;
+        List<Field> fields = new ArrayList<>();
+        // Enum constants carry the enum type name as their type.
+        if (ctx.enumeratives() != null) {
+            for (DRL10Parser.EnumerativeContext enumerative : ctx.enumeratives().enumerative()) {
+                if (enumerative.drlIdentifier() != null) {
+                    fields.add(new Field(enumerative.drlIdentifier().getText(), name,
+                                         extractEnumArgs(enumerative)));
+                }
+            }
+        }
+        fields.addAll(extractFields(ctx.field()));
+        return new DeclaredType(name, fields, true, nameLine, nameCol);
+    }
+
+    /**
+     * Returns the comma-separated constructor arguments of an enum constant
+     * ({@code LOW(1, "x")} → {@code 1, "x"}), or {@code null} when the
+     * constant has no argument list.
+     */
+    private static String extractEnumArgs(DRL10Parser.EnumerativeContext ctx) {
+        if (ctx == null || ctx.expression() == null || ctx.expression().isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ctx.expression().size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(ctx.expression(i).getText());
+        }
+        return sb.toString();
+    }
+
+    private static List<Field> extractFields(List<DRL10Parser.FieldContext> fieldCtxs) {
+        List<Field> fields = new ArrayList<>();
+        if (fieldCtxs == null) {
+            return fields;
+        }
+        for (DRL10Parser.FieldContext field : fieldCtxs) {
+            try {
+                if (field.label() == null || field.type() == null) {
+                    continue;
+                }
+                // label().getText() returns "name:" — strip the trailing colon.
+                String rawLabel = field.label().getText();
+                String fieldName = rawLabel.endsWith(":")
+                        ? rawLabel.substring(0, rawLabel.length() - 1).trim()
+                        : rawLabel.trim();
+                String fieldType = field.type().getText();
+                if (!fieldName.isEmpty() && !fieldType.isEmpty()) {
+                    fields.add(new Field(fieldName, fieldType));
+                }
+            } catch (Exception e) {
+                logger.fine(() -> "Skipping malformed field: " + e.getMessage());
+            }
+        }
+        return fields;
+    }
+}

--- a/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -4,12 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.antlr.v4.runtime.BaseErrorListener;
-import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
 import org.drools.drl.parser.antlr4.DRL10Parser;
-import org.drools.drl.parser.antlr4.DRLParserHelper;
 
 /**
  * Extracts {@link DeclaredType}s ({@code declare} blocks, including declared
@@ -21,39 +16,7 @@ public final class DRLDeclaredTypeParser {
     private static final Logger logger =
             Logger.getLogger(DRLDeclaredTypeParser.class.getName());
 
-    /** Swallows ANTLR parse errors — partial/incomplete DRL is normal here. */
-    private static final BaseErrorListener SILENT = new BaseErrorListener() {
-        @Override
-        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-                                int line, int charPositionInLine, String msg,
-                                RecognitionException e) {
-        }
-    };
-
     private DRLDeclaredTypeParser() {
-    }
-
-    /**
-     * Parses all {@code declare} blocks in {@code text}. Parser errors are
-     * ignored so partial files still yield partial results.
-     */
-    public static List<DeclaredType> parseDeclaredTypes(String text) {
-        List<DeclaredType> types = new ArrayList<>();
-        if (text == null || text.isBlank()) {
-            return types;
-        }
-        try {
-            DRL10Parser parser = DRLParserHelper.createDrlParser(text);
-            Lexer lexer = (Lexer) parser.getTokenStream().getTokenSource();
-            lexer.removeErrorListeners();
-            lexer.addErrorListener(SILENT);
-            parser.removeErrorListeners();
-            parser.addErrorListener(SILENT);
-            return extractFromCompilationUnit(parser.compilationUnit());
-        } catch (Exception e) {
-            logger.fine(() -> "Failed to parse DRL for declared types: " + e.getMessage());
-        }
-        return types;
     }
 
     /**

--- a/drools-completion/src/main/java/org/drools/completion/DeclaredType.java
+++ b/drools-completion/src/main/java/org/drools/completion/DeclaredType.java
@@ -1,0 +1,35 @@
+package org.drools.completion;
+
+import java.util.List;
+
+/** A type declared in DRL via a {@code declare} block. */
+public class DeclaredType {
+
+    public final String name;
+    public final List<Field> fields;
+    public final boolean isEnum;
+    /** 0-based line of the type name token (for future go-to-definition). */
+    public final int nameLine;
+    /** 0-based column of the type name token (for future go-to-definition). */
+    public final int nameCol;
+    /**
+     * Simple name of the parent type from {@code extends}, or {@code null}
+     * when no inheritance is declared.
+     */
+    public final String extendsName;
+
+    DeclaredType(String name, List<Field> fields, boolean isEnum,
+                 int nameLine, int nameCol) {
+        this(name, fields, isEnum, nameLine, nameCol, null);
+    }
+
+    DeclaredType(String name, List<Field> fields, boolean isEnum,
+                 int nameLine, int nameCol, String extendsName) {
+        this.name = name;
+        this.fields = fields;
+        this.isEnum = isEnum;
+        this.nameLine = nameLine;
+        this.nameCol = nameCol;
+        this.extendsName = extendsName;
+    }
+}

--- a/drools-completion/src/main/java/org/drools/completion/Field.java
+++ b/drools-completion/src/main/java/org/drools/completion/Field.java
@@ -1,0 +1,25 @@
+package org.drools.completion;
+
+/** A field, bean property, or enum constant of a {@link DeclaredType} or Java class. */
+public class Field {
+
+    public final String name;
+    public final String type;
+    /**
+     * For enum constants declared with constructor arguments
+     * (e.g. {@code LOW(1)}), the raw argument list as written in source —
+     * without the surrounding parentheses. {@code null} for ordinary fields
+     * and for enum constants without arguments.
+     */
+    public final String args;
+
+    Field(String name, String type) {
+        this(name, type, null);
+    }
+
+    Field(String name, String type, String args) {
+        this.name = name;
+        this.type = type;
+        this.args = args;
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
@@ -1,0 +1,61 @@
+package org.drools.completion;
+
+import java.util.List;
+
+import org.drools.completion.fixtures.InitProbe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClassMemberIndexTest {
+
+    private final ClassMemberIndex index =
+            new ClassMemberIndex(getClass().getClassLoader());
+
+    @Test
+    void exposesBeanPropertiesAndPublicFields() {
+        List<Field> members = index.membersOf("org.drools.completion.fixtures.Pet");
+
+        assertThat(members).extracting(f -> f.name)
+                .contains("name", "friendly", "legs");
+        assertThat(members).extracting(f -> f.name)
+                .doesNotContain("class", "getClass", "ignoredBecauseItTakesArgs");
+        assertThat(members)
+                .anySatisfy(f -> {
+                    assertThat(f.name).isEqualTo("name");
+                    assertThat(f.type).isEqualTo("String");
+                });
+    }
+
+    @Test
+    void reflectionDoesNotRunStaticInitializers() {
+        index.membersOf("org.drools.completion.fixtures.Pet");
+        assertThat(InitProbe.petInitialized)
+                .as("membersOf must not execute static initializers of user classes")
+                .isFalse();
+    }
+
+    @Test
+    void exposesEnumConstants() {
+        List<Field> members = index.membersOf("org.drools.completion.fixtures.PetKind");
+
+        assertThat(members).extracting(f -> f.name).contains("CAT", "DOG");
+        assertThat(members)
+                .anySatisfy(f -> {
+                    assertThat(f.name).isEqualTo("CAT");
+                    assertThat(f.type).isEqualTo("PetKind");
+                });
+    }
+
+    @Test
+    void unknownClassYieldsNoMembers() {
+        assertThat(index.membersOf("does.not.Exist")).isEmpty();
+        // Negative result is cached and stays consistent.
+        assertThat(index.membersOf("does.not.Exist")).isEmpty();
+    }
+
+    @Test
+    void emptyIndexYieldsNoMembers() {
+        assertThat(ClassMemberIndex.empty().membersOf("java.lang.String")).isEmpty();
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
@@ -59,4 +59,16 @@ class ClassMemberIndexTest {
     void emptyIndexYieldsNoMembers() {
         assertThat(ClassMemberIndex.empty().membersOf("java.lang.String")).isEmpty();
     }
+
+    @Test
+    void closingDoesNotCloseExternallyOwnedLoader() throws Exception {
+        ClassLoader borrowed = getClass().getClassLoader();
+        ClassMemberIndex borrowedIndex = new ClassMemberIndex(borrowed);
+
+        borrowedIndex.close();
+        borrowedIndex.close();
+
+        assertThat(borrowed.loadClass("java.lang.String")).isNotNull();
+        ClassMemberIndex.empty().close(); // must not throw
+    }
 }

--- a/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/ClassMemberIndexTest.java
@@ -19,7 +19,8 @@ class ClassMemberIndexTest {
         assertThat(members).extracting(f -> f.name)
                 .contains("name", "friendly", "legs");
         assertThat(members).extracting(f -> f.name)
-                .doesNotContain("class", "getClass", "ignoredBecauseItTakesArgs");
+                // namedAfter: isNamedAfter() returns String, not boolean — not a property.
+                .doesNotContain("class", "getClass", "ignoredBecauseItTakesArgs", "namedAfter");
         assertThat(members)
                 .anySatisfy(f -> {
                     assertThat(f.name).isEqualTo("name");

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -101,11 +101,12 @@ class DRLCompletionHelperTest {
         result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
         assertThat(completionItemStrings(result)).contains("exists", "not"); // inside LHS
 
-        // `    $dog : Dog(`
+        // `    $dog : Dog(` — caret right after the opening paren now offers
+        // constraint-expression completion instead of nothing.
         caretPosition.setLine(8);
         caretPosition.setCharacter(15);
         result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
-        assertThat(result).isEmpty(); // no completion for identifier
+        assertThat(completionItemStrings(result)).contains("new", "boolean");
 
         // `  th`
         caretPosition.setLine(9);
@@ -265,6 +266,32 @@ class DRLCompletionHelperTest {
 
         ClassMemberIndex memberIndex = new ClassMemberIndex(getClass().getClassLoader());
         Position caretPosition = new Position(6, 9);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient(), ClassIndex.empty(), memberIndex);
+
+        List<String> fieldLabels = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Field)
+                .map(CompletionItem::getLabel)
+                .toList();
+        assertThat(fieldLabels).contains("name", "friendly", "legs");
+    }
+
+    @Test
+    void fieldCompletionWithCaretRightAfterOpeningParen() {
+        String text = """
+                package demo;
+
+                import org.drools.completion.fixtures.Pet;
+
+                rule R
+                  when
+                    Pet(
+                  then
+                end
+                """;
+
+        ClassMemberIndex memberIndex = new ClassMemberIndex(getClass().getClassLoader());
+        Position caretPosition = new Position(6, 8); // right after 'Pet('
         List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
                 text, caretPosition, getLanguageClient(), ClassIndex.empty(), memberIndex);
 

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -101,12 +101,13 @@ class DRLCompletionHelperTest {
         result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
         assertThat(completionItemStrings(result)).contains("exists", "not"); // inside LHS
 
-        // `    $dog : Dog(` — caret right after the opening paren now offers
-        // constraint-expression completion instead of nothing.
+        // `    $dog : Dog(` — constraint position. The expression-starter keyword
+        // noise is filtered out, and with no class/member index Dog's fields
+        // can't be resolved here, so nothing is offered.
         caretPosition.setLine(8);
         caretPosition.setCharacter(15);
         result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
-        assertThat(completionItemStrings(result)).contains("new", "boolean");
+        assertThat(result).isEmpty();
 
         // `  th`
         caretPosition.setLine(9);
@@ -300,6 +301,37 @@ class DRLCompletionHelperTest {
                 .map(CompletionItem::getLabel)
                 .toList();
         assertThat(fieldLabels).contains("name", "friendly", "legs");
+    }
+
+    @Test
+    void constraintPositionOmitsPrimitiveKeywordNoise() {
+        // Inside a pattern's parens c3 also predicts Java expression starters
+        // (boolean/int/new/super/literal tokens). Those are dropped so only the
+        // field completions remain; primitive types stay available elsewhere.
+        String text = """
+                package test;
+
+                declare TestFact
+                    name: String
+                    type: String
+                end
+
+                rule R
+                when
+                    TestFact(  )
+                then
+                end
+                """;
+
+        Position caretPosition = new Position(9, 13); // between the parens of TestFact(  )
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient());
+
+        List<String> labels = result.stream().map(CompletionItem::getLabel).toList();
+        assertThat(labels).contains("name", "type");
+        assertThat(labels).doesNotContain(
+                "boolean", "byte", "char", "short", "int", "long", "float", "double",
+                "new", "super", "drl_big_decimal_literal", "drl_big_integer_literal");
     }
 
     @Test

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -217,6 +217,64 @@ class DRLCompletionHelperTest {
         }
     }
 
+    @Test
+    void fieldCompletionFromDeclaredType() {
+        String text = """
+                package demo;
+
+                declare Person
+                  name : String
+                  age : int
+                end
+
+                rule R
+                  when
+                    Person(  )
+                  then
+                end
+                """;
+
+        // Inside the pattern's parens.
+        Position caretPosition = new Position(9, 12);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient(), ClassIndex.empty());
+
+        List<CompletionItem> fieldItems = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Field)
+                .toList();
+        assertThat(fieldItems).extracting(CompletionItem::getLabel)
+                .contains("name", "age");
+        CompletionItem nameItem = fieldItems.stream()
+                .filter(item -> item.getLabel().equals("name")).findFirst().orElseThrow();
+        assertThat(nameItem.getDetail()).isEqualTo("String");
+    }
+
+    @Test
+    void fieldCompletionFromClasspathTypeViaImport() {
+        String text = """
+                package demo;
+
+                import org.drools.completion.fixtures.Pet;
+
+                rule R
+                  when
+                    Pet(  )
+                  then
+                end
+                """;
+
+        ClassMemberIndex memberIndex = new ClassMemberIndex(getClass().getClassLoader());
+        Position caretPosition = new Position(6, 9);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient(), ClassIndex.empty(), memberIndex);
+
+        List<String> fieldLabels = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Field)
+                .map(CompletionItem::getLabel)
+                .toList();
+        assertThat(fieldLabels).contains("name", "friendly", "legs");
+    }
+
     private List<String> completionItemStrings(List<CompletionItem> result) {
         return result.stream().map(CompletionItem::getInsertText).toList();
     }

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -275,6 +275,17 @@ class DRLCompletionHelperTest {
         assertThat(fieldLabels).contains("name", "friendly", "legs");
     }
 
+    @Test
+    void caretBeyondLastTokenDoesNotThrow() {
+        String text = "package demo;\n\nrule R\nwhen\nthen\nend\n";
+        Position caretPosition = new Position(6, 0);
+
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient());
+
+        assertThat(result).isNotNull();
+    }
+
     private List<String> completionItemStrings(List<CompletionItem> result) {
         return result.stream().map(CompletionItem::getInsertText).toList();
     }

--- a/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
@@ -2,11 +2,19 @@ package org.drools.completion;
 
 import java.util.List;
 
+import org.drools.drl.parser.antlr4.DRL10Parser;
+import org.drools.drl.parser.antlr4.DRLParserHelper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DRLDeclaredTypeParserTest {
+
+    private static List<DeclaredType> parse(String drl) {
+        DRL10Parser parser = DRLParserHelper.createDrlParser(drl);
+        parser.removeErrorListeners(); // partial/malformed DRL is expected here
+        return DRLDeclaredTypeParser.extractFromCompilationUnit(parser.compilationUnit());
+    }
 
     @Test
     void parsesDeclaredTypeWithFields() {
@@ -15,7 +23,7 @@ class DRLDeclaredTypeParserTest {
                 + "  name : String\n"
                 + "  age : int\n"
                 + "end\n";
-        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+        List<DeclaredType> types = parse(drl);
 
         assertThat(types).hasSize(1);
         DeclaredType person = types.get(0);
@@ -31,7 +39,7 @@ class DRLDeclaredTypeParserTest {
                 + "  LOW(1), HIGH(2);\n"
                 + "  level : int\n"
                 + "end\n";
-        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+        List<DeclaredType> types = parse(drl);
 
         assertThat(types).hasSize(1);
         DeclaredType severity = types.get(0);
@@ -47,7 +55,7 @@ class DRLDeclaredTypeParserTest {
         String drl = "declare Employee extends Person\n"
                 + "  salary : double\n"
                 + "end\n";
-        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+        List<DeclaredType> types = parse(drl);
 
         assertThat(types).hasSize(1);
         assertThat(types.get(0).extendsName).isEqualTo("Person");
@@ -62,14 +70,14 @@ class DRLDeclaredTypeParserTest {
                 + "  id : long\n"
                 + "end\n"
                 + "rule broken when Person( then\n";
-        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+        List<DeclaredType> types = parse(drl);
 
         assertThat(types).extracting(t -> t.name).contains("Alpha");
     }
 
     @Test
     void nullAndEmptyTextYieldNoTypes() {
-        assertThat(DRLDeclaredTypeParser.parseDeclaredTypes(null)).isEmpty();
-        assertThat(DRLDeclaredTypeParser.parseDeclaredTypes("")).isEmpty();
+        assertThat(DRLDeclaredTypeParser.extractFromCompilationUnit(null)).isEmpty();
+        assertThat(parse("")).isEmpty();
     }
 }

--- a/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
@@ -1,0 +1,75 @@
+package org.drools.completion;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DRLDeclaredTypeParserTest {
+
+    @Test
+    void parsesDeclaredTypeWithFields() {
+        String drl = "package demo;\n"
+                + "declare Person\n"
+                + "  name : String\n"
+                + "  age : int\n"
+                + "end\n";
+        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+
+        assertThat(types).hasSize(1);
+        DeclaredType person = types.get(0);
+        assertThat(person.name).isEqualTo("Person");
+        assertThat(person.isEnum).isFalse();
+        assertThat(person.fields).extracting(f -> f.name).containsExactly("name", "age");
+        assertThat(person.fields).extracting(f -> f.type).containsExactly("String", "int");
+    }
+
+    @Test
+    void parsesDeclaredEnumWithConstants() {
+        String drl = "declare enum Severity\n"
+                + "  LOW(1), HIGH(2);\n"
+                + "  level : int\n"
+                + "end\n";
+        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+
+        assertThat(types).hasSize(1);
+        DeclaredType severity = types.get(0);
+        assertThat(severity.isEnum).isTrue();
+        assertThat(severity.fields).extracting(f -> f.name)
+                .contains("LOW", "HIGH", "level");
+        assertThat(severity.fields.get(0).type).isEqualTo("Severity");
+        assertThat(severity.fields.get(0).args).isEqualTo("1");
+    }
+
+    @Test
+    void recordsExtendsParent() {
+        String drl = "declare Employee extends Person\n"
+                + "  salary : double\n"
+                + "end\n";
+        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+
+        assertThat(types).hasSize(1);
+        assertThat(types.get(0).extendsName).isEqualTo("Person");
+    }
+
+    @Test
+    void malformedSurroundingsStillYieldPartialResults() {
+        // Parse errors after the declare must neither throw nor discard the
+        // already-parsed type. (Recovery from errors *before* a declare may
+        // legitimately consume it — partial results are best-effort.)
+        String drl = "declare Alpha\n"
+                + "  id : long\n"
+                + "end\n"
+                + "rule broken when Person( then\n";
+        List<DeclaredType> types = DRLDeclaredTypeParser.parseDeclaredTypes(drl);
+
+        assertThat(types).extracting(t -> t.name).contains("Alpha");
+    }
+
+    @Test
+    void nullAndEmptyTextYieldNoTypes() {
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypes(null)).isEmpty();
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypes("")).isEmpty();
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/fixtures/InitProbe.java
+++ b/drools-completion/src/test/java/org/drools/completion/fixtures/InitProbe.java
@@ -1,0 +1,10 @@
+package org.drools.completion.fixtures;
+
+/** Records whether {@link Pet}'s static initializer ran. */
+public final class InitProbe {
+
+    public static volatile boolean petInitialized = false;
+
+    private InitProbe() {
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/fixtures/Pet.java
+++ b/drools-completion/src/test/java/org/drools/completion/fixtures/Pet.java
@@ -1,0 +1,25 @@
+package org.drools.completion.fixtures;
+
+/** Reflection fixture for ClassMemberIndex tests. */
+public class Pet {
+
+    static {
+        InitProbe.petInitialized = true;
+    }
+
+    public int legs;
+    private String name;
+    private boolean friendly;
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isFriendly() {
+        return friendly;
+    }
+
+    public String ignoredBecauseItTakesArgs(String arg) {
+        return arg;
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/fixtures/Pet.java
+++ b/drools-completion/src/test/java/org/drools/completion/fixtures/Pet.java
@@ -19,6 +19,11 @@ public class Pet {
         return friendly;
     }
 
+    // 'is' prefix but non-boolean return — not a JavaBeans property.
+    public String isNamedAfter() {
+        return name;
+    }
+
     public String ignoredBecauseItTakesArgs(String arg) {
         return arg;
     }

--- a/drools-completion/src/test/java/org/drools/completion/fixtures/PetKind.java
+++ b/drools-completion/src/test/java/org/drools/completion/fixtures/PetKind.java
@@ -1,0 +1,7 @@
+package org.drools.completion.fixtures;
+
+/** Enum reflection fixture for ClassMemberIndex tests. */
+public enum PetKind {
+    CAT,
+    DOG
+}

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.drools.completion.ClassIndex;
+import org.drools.completion.ClassMemberIndex;
 import org.drools.completion.DRLCompletionHelper;
 import org.drools.drl.parser.antlr4.DRLParserHelper;
 import org.eclipse.lsp4j.CompletionItem;
@@ -30,6 +31,7 @@ public class DroolsLspDocumentService implements TextDocumentService {
 
     private final Map<String, String> sourcesMap = new ConcurrentHashMap<>();
     private volatile ClassIndex classIndex = ClassIndex.empty();
+    private volatile ClassMemberIndex classMemberIndex = ClassMemberIndex.empty();
 
     private final DroolsLspServer server;
 
@@ -39,6 +41,10 @@ public class DroolsLspDocumentService implements TextDocumentService {
 
     public void setClassIndex(ClassIndex classIndex) {
         this.classIndex = classIndex;
+    }
+
+    public void setClassMemberIndex(ClassMemberIndex classMemberIndex) {
+        this.classMemberIndex = classMemberIndex;
     }
 
     ClassIndex getClassIndexForTest() {
@@ -102,7 +108,7 @@ public class DroolsLspDocumentService implements TextDocumentService {
         String text = sourcesMap.get(completionParams.getTextDocument().getUri());
 
         Position caretPosition = completionParams.getPosition();
-        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient(), classIndex);
+        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient(), classIndex, classMemberIndex);
 
         server.getClient().showMessage(new MessageParams(MessageType.Info, "Position=" + caretPosition));
         server.getClient().showMessage(new MessageParams(MessageType.Info, "completionItems = " + completionItems));

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -33,6 +33,7 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
     private volatile Set<Path> classpathEntries = Set.of();
     private volatile Set<Path> buildOutputDirs = Set.of();
     private volatile ClassIndex jarClassIndex = ClassIndex.empty();
+    private volatile ClassMemberIndex classMemberIndex = ClassMemberIndex.empty();
 
     /** Tracks whether {@code shutdown} preceded {@code exit} (LSP spec). */
     private volatile boolean shutdownReceived = false;
@@ -64,6 +65,8 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         try {
             ClassIndex outputIndex = ClassIndex.build(dirs);
             textService.setClassIndex(ClassIndex.merge(jarClassIndex, outputIndex));
+            // Fresh loader so recompiled classes aren't served from the old one's cache.
+            swapMemberIndex(ClassMemberIndex.of(classpathEntries));
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to rebuild class index", e);
         }
@@ -76,7 +79,20 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         this.jarClassIndex = jars.isEmpty() ? ClassIndex.empty() : ClassIndex.build(jars);
         // Member lookup reflects over the full classpath (jars + class dirs)
         // lazily — building the index itself loads no classes.
-        textService.setClassMemberIndex(ClassMemberIndex.of(entries));
+        swapMemberIndex(ClassMemberIndex.of(entries));
+    }
+
+    private synchronized void swapMemberIndex(ClassMemberIndex next) {
+        ClassMemberIndex previous = this.classMemberIndex;
+        this.classMemberIndex = next;
+        textService.setClassMemberIndex(next);
+        if (previous != next) {
+            try {
+                previous.close();
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to close previous class member index", e);
+            }
+        }
     }
 
     void setClasspathEntriesForTest(Set<Path> entries) {
@@ -132,6 +148,11 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
     @Override
     public CompletableFuture<Object> shutdown() {
         shutdownReceived = true;
+        try {
+            classMemberIndex.close();
+        } catch (Exception e) {
+            logger.log(Level.FINE, "Failed to close class member index on shutdown", e);
+        }
         return CompletableFuture.completedFuture(null);
     }
 

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.drools.completion.ClassIndex;
+import org.drools.completion.ClassMemberIndex;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -70,6 +71,9 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         this.buildOutputDirs = filterDirectories(entries);
         Set<Path> jars = filterJars(entries);
         this.jarClassIndex = jars.isEmpty() ? ClassIndex.empty() : ClassIndex.build(jars);
+        // Member lookup reflects over the full classpath (jars + class dirs)
+        // lazily — building the index itself loads no classes.
+        textService.setClassMemberIndex(ClassMemberIndex.of(entries));
     }
 
     void setClasspathEntriesForTest(Set<Path> entries) {


### PR DESCRIPTION
Adds member/field completion on top of the class-name completion from backed by an in-process type index (Java sources + JARs) and a pluggable workspace-grouping SPI

Completing inside a pattern's parens now offers the fields of the pattern's type, extending the class-name completion from #74 down to the member level. C3 distinguishes the two positions: type-name completion fires on drlQualifiedName in lhsPattern position, field completion on drlIdentifier candidates whose rule path crosses `constraint`. The enclosing pattern's type comes straight from the parse tree (LhsPatternContext.objectType).

Two type sources:

- DRL `declare` blocks in the current document, extracted from the already-parsed compilation unit by the new DRLDeclaredTypeParser (fields, declared enums with constants/args, extends) - no second parse, and types that exist only in DRL complete without any build.
- Compiled classes from the resolved classpath via the new ClassMemberIndex: enum constants, bean properties from public no-arg getters (inherited included), and public fields. Classes load with Class.forName(fqcn, false, loader), so static initializers never run inside the language server, and the loader parents the platform class loader so server-internal classes cannot leak into completions. Results (including misses) are cached per FQCN. Type names resolve through imports first, then the class index.