### PR TITLE
Feat/workspace siblings

### DIFF
--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -144,7 +144,7 @@ public class DRLCompletionHelper {
         }
 
         if (constraintPosition) {
-            items.addAll(getFieldCompletionItems(compilationUnit, nodeIndex, classIndex, memberIndex, documentPath));
+            items.addAll(getFieldCompletionItems(compilationUnit, patternTokenIndex, classIndex, memberIndex, documentPath));
         }
 
         return items;
@@ -163,9 +163,9 @@ public class DRLCompletionHelper {
      * class index.
      */
     private static List<CompletionItem> getFieldCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit,
-                                                                int nodeIndex, ClassIndex classIndex,
+                                                                int patternTokenIndex, ClassIndex classIndex,
                                                                 ClassMemberIndex memberIndex, Path documentPath) {
-        String patternType = findEnclosingPatternTypeName(compilationUnit, nodeIndex);
+        String patternType = findEnclosingPatternTypeName(compilationUnit, patternTokenIndex);
         if (patternType == null || patternType.isEmpty()) {
             return List.of();
         }

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -15,6 +15,7 @@
  */
 package org.drools.completion;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -59,6 +60,15 @@ public class DRLCompletionHelper {
     }
 
     public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client, ClassIndex classIndex, ClassMemberIndex memberIndex) {
+        return getCompletionItems(text, caretPosition, client, classIndex, memberIndex, null);
+    }
+
+    /**
+     * @param documentPath filesystem location of the document, used to find
+     *                     sibling DRL files; {@code null} for non-file
+     *                     documents (sibling declares are then unavailable)
+     */
+    public static List<CompletionItem> getCompletionItems(String text, Position caretPosition, LanguageClient client, ClassIndex classIndex, ClassMemberIndex memberIndex, Path documentPath) {
         DRL10Parser drlParser = createDrlParser(text);
 
         int row = caretPosition == null ? -1 : caretPosition.getLine() + 1; // caret line position is zero based
@@ -68,14 +78,14 @@ public class DRLCompletionHelper {
         Integer nodeIndex = computeTokenIndex(drlParser, row, col);
         String prefix = extractPrefix(drlParser, nodeIndex);
 
-        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix, memberIndex);
+        return getCompletionItems(drlParser, nodeIndex, compilationUnit, classIndex, prefix, memberIndex, documentPath);
     }
 
     static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex) {
-        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "", ClassMemberIndex.empty());
+        return getCompletionItems(drlParser, nodeIndex, null, ClassIndex.empty(), "", ClassMemberIndex.empty(), null);
     }
 
-    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix, ClassMemberIndex memberIndex) {
+    static List<CompletionItem> getCompletionItems(DRL10Parser drlParser, int nodeIndex, DRL10Parser.CompilationUnitContext compilationUnit, ClassIndex classIndex, String prefix, ClassMemberIndex memberIndex, Path documentPath) {
         CodeCompletionCore core = new CodeCompletionCore(drlParser, PREFERRED_RULES, Tokens.IGNORED);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(nodeIndex, null);
 
@@ -95,7 +105,7 @@ public class DRLCompletionHelper {
         }
 
         if (compilationUnit != null && isConstraintPosition(candidates)) {
-            items.addAll(getFieldCompletionItems(compilationUnit, nodeIndex, classIndex, memberIndex));
+            items.addAll(getFieldCompletionItems(compilationUnit, nodeIndex, classIndex, memberIndex, documentPath));
         }
 
         return items;
@@ -108,23 +118,33 @@ public class DRLCompletionHelper {
 
     /**
      * Completion items for the fields of the pattern enclosing the caret:
-     * fields of a DRL-declared type in the same document, or bean
+     * fields of a DRL-declared type (current document first, then sibling
+     * files from the active {@link WorkspaceSiblingResolver}), or bean
      * properties/fields of a classpath type resolved through imports and the
      * class index.
      */
     private static List<CompletionItem> getFieldCompletionItems(DRL10Parser.CompilationUnitContext compilationUnit,
                                                                 int nodeIndex, ClassIndex classIndex,
-                                                                ClassMemberIndex memberIndex) {
+                                                                ClassMemberIndex memberIndex, Path documentPath) {
         String patternType = findEnclosingPatternTypeName(compilationUnit, nodeIndex);
         if (patternType == null || patternType.isEmpty()) {
             return List.of();
         }
         String simpleName = patternType.substring(patternType.lastIndexOf('.') + 1);
 
-        // DRL-declared types in the current document win over classpath types.
+        // DRL-declared types win over classpath types.
         for (DeclaredType declared : DRLDeclaredTypeParser.extractFromCompilationUnit(compilationUnit)) {
             if (simpleName.equals(declared.name)) {
                 return fieldItems(declared.fields);
+            }
+        }
+        if (documentPath != null) {
+            for (Path sibling : WorkspaceSiblingResolvers.active().resolveSiblings(documentPath)) {
+                for (DeclaredType declared : DRLDeclaredTypeParser.parseDeclaredTypesCached(sibling)) {
+                    if (simpleName.equals(declared.name)) {
+                        return fieldItems(declared.fields);
+                    }
+                }
             }
         }
 

--- a/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +41,8 @@ import static org.drools.drl.parser.antlr4.DRLParserHelper.computeTokenIndex;
 import static org.drools.drl.parser.antlr4.DRLParserHelper.createDrlParser;
 
 public class DRLCompletionHelper {
+
+    private static final Logger logger = Logger.getLogger(DRLCompletionHelper.class.getName());
 
     // PREFERRED_RULES is used to filter out the rules that consist of unwanted tokens
     // additionally, it can be used to customize getCompletionItems behavior
@@ -223,10 +227,21 @@ public class DRLCompletionHelper {
                 return imported;
             }
         }
+        // The import/qualified-name checks above are the disambiguators. Falling
+        // through to the class index means the name is unqualified, so an
+        // ambiguous simple name (two classpath classes, same simple name)
+        Set<String> matches = new HashSet<>();
         for (String fqcn : classIndex.getMatching(simpleName)) {
             if (fqcn.endsWith("." + simpleName) || fqcn.equals(simpleName)) {
-                return fqcn;
+                matches.add(fqcn);
             }
+        }
+        if (matches.size() == 1) {
+            return matches.iterator().next();
+        }
+        if (matches.size() > 1) {
+            logger.log(Level.FINE, () -> "Ambiguous simple name '" + simpleName
+                    + "' matches " + matches + "; skipping field completion");
         }
         return null;
     }

--- a/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -52,6 +52,16 @@ public final class DRLDeclaredTypeParser {
     private static final Map<Path, CachedEntry> FILE_CACHE = new ConcurrentHashMap<>();
 
     /**
+     * Drops all cached parse results. Entries are already mtime-validated, so
+     * this is about bounding memory in a long-running server rather than
+     * correctness; call it when the workspace classpath is rebuilt or on
+     * shutdown.
+     */
+    public static void clearCache() {
+        FILE_CACHE.clear();
+    }
+
+    /**
      * Parses declared types from a file, serving a cached result while the
      * file's modification time is unchanged. Missing/unreadable files yield
      * an empty list.

--- a/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -1,7 +1,12 @@
 package org.drools.completion;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -31,6 +36,45 @@ public final class DRLDeclaredTypeParser {
     };
 
     private DRLDeclaredTypeParser() {
+    }
+
+    private static final class CachedEntry {
+        final long modMillis;
+        final List<DeclaredType> types;
+
+        CachedEntry(long modMillis, List<DeclaredType> types) {
+            this.modMillis = modMillis;
+            this.types = types;
+        }
+    }
+
+    /** Per-file cache keyed by normalized absolute path, valid by mtime. */
+    private static final Map<Path, CachedEntry> FILE_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Parses declared types from a file, serving a cached result while the
+     * file's modification time is unchanged. Missing/unreadable files yield
+     * an empty list.
+     */
+    public static List<DeclaredType> parseDeclaredTypesCached(Path file) {
+        if (file == null || !Files.isRegularFile(file)) {
+            return Collections.emptyList();
+        }
+        try {
+            Path key = file.toAbsolutePath().normalize();
+            long modMillis = Files.getLastModifiedTime(file).toMillis();
+            CachedEntry cached = FILE_CACHE.get(key);
+            if (cached != null && cached.modMillis == modMillis) {
+                return cached.types;
+            }
+            List<DeclaredType> types =
+                    Collections.unmodifiableList(parseDeclaredTypes(Files.readString(file)));
+            FILE_CACHE.put(key, new CachedEntry(modMillis, types));
+            return types;
+        } catch (Exception e) {
+            logger.fine(() -> "Failed to read/parse " + file + ": " + e.getMessage());
+            return Collections.emptyList();
+        }
     }
 
     /**

--- a/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -9,7 +9,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
 import org.drools.drl.parser.antlr4.DRL10Parser;
+import org.drools.drl.parser.antlr4.DRLParserHelper;
 
 /**
  * Extracts {@link DeclaredType}s ({@code declare} blocks, including declared
@@ -20,6 +25,15 @@ public final class DRLDeclaredTypeParser {
 
     private static final Logger logger =
             Logger.getLogger(DRLDeclaredTypeParser.class.getName());
+
+    /** Swallows ANTLR parse errors — partial/incomplete DRL is normal here. */
+    private static final BaseErrorListener SILENT = new BaseErrorListener() {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg,
+                                RecognitionException e) {
+        }
+    };
 
     private DRLDeclaredTypeParser() {
     }
@@ -61,6 +75,29 @@ public final class DRLDeclaredTypeParser {
             logger.fine(() -> "Failed to read/parse " + file + ": " + e.getMessage());
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Parses all {@code declare} blocks in {@code text}. Parser errors are
+     * ignored so partial files still yield partial results.
+     */
+    private static List<DeclaredType> parseDeclaredTypes(String text) {
+        List<DeclaredType> types = new ArrayList<>();
+        if (text == null || text.isBlank()) {
+            return types;
+        }
+        try {
+            DRL10Parser parser = DRLParserHelper.createDrlParser(text);
+            Lexer lexer = (Lexer) parser.getTokenStream().getTokenSource();
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(SILENT);
+            parser.removeErrorListeners();
+            parser.addErrorListener(SILENT);
+            return extractFromCompilationUnit(parser.compilationUnit());
+        } catch (Exception e) {
+            logger.fine(() -> "Failed to parse DRL for declared types: " + e.getMessage());
+        }
+        return types;
     }
 
     /**

--- a/drools-completion/src/main/java/org/drools/completion/WorkspaceSiblingResolver.java
+++ b/drools-completion/src/main/java/org/drools/completion/WorkspaceSiblingResolver.java
@@ -1,0 +1,25 @@
+package org.drools.completion;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Resolves the set of DRL files that should be considered "siblings" of a
+ * given document — files in the same logical group whose declared types are
+ * in scope for completion and navigation.
+ *
+ * <p>The default resolver (see {@link WorkspaceSiblingResolvers}) groups by
+ * directory: every other {@code .drl} file beside the current one. Hosts
+ * with an explicit grouping model (build configuration, rule sets, …) can
+ * install their own implementation via
+ * {@link WorkspaceSiblingResolvers#setActive}.
+ */
+public interface WorkspaceSiblingResolver {
+
+    /**
+     * Returns the absolute paths of the files grouped with
+     * {@code currentFile} (excluding the file itself), or an empty list when
+     * no grouping applies.
+     */
+    List<Path> resolveSiblings(Path currentFile);
+}

--- a/drools-completion/src/main/java/org/drools/completion/WorkspaceSiblingResolvers.java
+++ b/drools-completion/src/main/java/org/drools/completion/WorkspaceSiblingResolvers.java
@@ -1,0 +1,59 @@
+package org.drools.completion;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Process-wide registry for the active {@link WorkspaceSiblingResolver}.
+ * Defaults to directory grouping: all other {@code .drl} files in the same
+ * directory as the current document, in stable (sorted) order.
+ */
+public final class WorkspaceSiblingResolvers {
+
+    private static final WorkspaceSiblingResolver SAME_DIRECTORY =
+            WorkspaceSiblingResolvers::sameDirectorySiblings;
+
+    private static volatile WorkspaceSiblingResolver active = SAME_DIRECTORY;
+
+    private WorkspaceSiblingResolvers() {
+    }
+
+    public static WorkspaceSiblingResolver active() {
+        return active;
+    }
+
+    /**
+     * Installs {@code resolver}, or restores the same-directory default when
+     * {@code null}.
+     */
+    public static void setActive(WorkspaceSiblingResolver resolver) {
+        active = (resolver == null) ? SAME_DIRECTORY : resolver;
+    }
+
+    private static List<Path> sameDirectorySiblings(Path currentFile) {
+        if (currentFile == null) {
+            return Collections.emptyList();
+        }
+        Path dir = currentFile.toAbsolutePath().getParent();
+        if (dir == null || !Files.isDirectory(dir)) {
+            return Collections.emptyList();
+        }
+        Path normalizedCurrent = currentFile.toAbsolutePath().normalize();
+        List<Path> siblings = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "*.drl")) {
+            for (Path candidate : stream) {
+                if (!candidate.toAbsolutePath().normalize().equals(normalizedCurrent)) {
+                    siblings.add(candidate);
+                }
+            }
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+        siblings.sort(Path::compareTo);
+        return siblings;
+    }
+}

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -247,6 +248,36 @@ class DRLCompletionHelperTest {
         CompletionItem nameItem = fieldItems.stream()
                 .filter(item -> item.getLabel().equals("name")).findFirst().orElseThrow();
         assertThat(nameItem.getDetail()).isEqualTo("String");
+    }
+
+    @Test
+    void fieldCompletionFromSiblingFileDeclare(@TempDir Path tmp) throws IOException {
+        // The Person type is declared in a sibling .drl file in the same
+        // directory as the current document.
+        Files.writeString(tmp.resolve("Types.drl"),
+                "package demo;\ndeclare Person\n  name : String\n  age : int\nend\n");
+        Path currentDoc = tmp.resolve("rules.drl");
+        String text = """
+                package demo;
+
+                rule R
+                  when
+                    Person(  )
+                  then
+                end
+                """;
+        Files.writeString(currentDoc, text);
+
+        Position caretPosition = new Position(4, 12);
+        List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(
+                text, caretPosition, getLanguageClient(),
+                ClassIndex.empty(), ClassMemberIndex.empty(), currentDoc);
+
+        List<String> fieldLabels = result.stream()
+                .filter(item -> item.getKind() == CompletionItemKind.Field)
+                .map(CompletionItem::getLabel)
+                .toList();
+        assertThat(fieldLabels).contains("name", "age");
     }
 
     @Test

--- a/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLDeclaredTypeParserTest.java
@@ -1,8 +1,11 @@
 package org.drools.completion;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,5 +74,30 @@ class DRLDeclaredTypeParserTest {
     void nullAndEmptyTextYieldNoTypes() {
         assertThat(DRLDeclaredTypeParser.parseDeclaredTypes(null)).isEmpty();
         assertThat(DRLDeclaredTypeParser.parseDeclaredTypes("")).isEmpty();
+    }
+
+    @Test
+    void cachedFileParsingTracksModificationTime(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Types.drl");
+        Files.writeString(file, "declare Alpha\n  id : long\nend\n");
+
+        List<DeclaredType> first = DRLDeclaredTypeParser.parseDeclaredTypesCached(file);
+        assertThat(first).extracting(t -> t.name).containsExactly("Alpha");
+
+        // Unchanged file: the cached list is served (same instance).
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypesCached(file)).isSameAs(first);
+
+        // Changed content with a new mtime is re-parsed.
+        Files.writeString(file, "declare Beta\n  id : long\nend\n");
+        Files.setLastModifiedTime(file, java.nio.file.attribute.FileTime.fromMillis(
+                Files.getLastModifiedTime(file).toMillis() + 5_000));
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypesCached(file))
+                .extracting(t -> t.name).containsExactly("Beta");
+    }
+
+    @Test
+    void cachedFileParsingHandlesMissingFiles(@TempDir Path tmp) {
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypesCached(tmp.resolve("missing.drl"))).isEmpty();
+        assertThat(DRLDeclaredTypeParser.parseDeclaredTypesCached(null)).isEmpty();
     }
 }

--- a/drools-completion/src/test/java/org/drools/completion/WorkspaceSiblingResolversTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/WorkspaceSiblingResolversTest.java
@@ -1,0 +1,49 @@
+package org.drools.completion;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkspaceSiblingResolversTest {
+
+    @AfterEach
+    void resetResolver() {
+        WorkspaceSiblingResolvers.setActive(null);
+    }
+
+    @Test
+    void defaultResolverReturnsSameDirectoryDrlFiles(@TempDir Path tmp) throws Exception {
+        Path a = Files.createFile(tmp.resolve("A.drl"));
+        Path b = Files.createFile(tmp.resolve("B.drl"));
+        Files.createFile(tmp.resolve("notes.txt"));
+
+        List<Path> siblings = WorkspaceSiblingResolvers.active().resolveSiblings(a);
+
+        assertThat(siblings).containsExactly(b);
+    }
+
+    @Test
+    void defaultResolverHandlesNullAndMissingPaths(@TempDir Path tmp) {
+        assertThat(WorkspaceSiblingResolvers.active().resolveSiblings(null)).isEmpty();
+        assertThat(WorkspaceSiblingResolvers.active()
+                .resolveSiblings(tmp.resolve("missing/X.drl"))).isEmpty();
+    }
+
+    @Test
+    void setActiveSwapsResolverAndNullRestoresDefault(@TempDir Path tmp) throws Exception {
+        Path a = Files.createFile(tmp.resolve("A.drl"));
+        Path b = Files.createFile(tmp.resolve("B.drl"));
+
+        WorkspaceSiblingResolvers.setActive(file -> List.of());
+        assertThat(WorkspaceSiblingResolvers.active().resolveSiblings(a)).isEmpty();
+
+        WorkspaceSiblingResolvers.setActive(null);
+        assertThat(WorkspaceSiblingResolvers.active().resolveSiblings(a)).containsExactly(b);
+    }
+}

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspDocumentService.java
@@ -1,5 +1,8 @@
 package org.drools.lsp.server;
 
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -105,15 +108,25 @@ public class DroolsLspDocumentService implements TextDocumentService {
     }
 
     public List<CompletionItem> getCompletionItems(CompletionParams completionParams) {
-        String text = sourcesMap.get(completionParams.getTextDocument().getUri());
+        String uri = completionParams.getTextDocument().getUri();
+        String text = sourcesMap.get(uri);
 
         Position caretPosition = completionParams.getPosition();
-        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient(), classIndex, classMemberIndex);
+        List<CompletionItem> completionItems = DRLCompletionHelper.getCompletionItems(text, caretPosition, server.getClient(), classIndex, classMemberIndex, toPath(uri));
 
         server.getClient().showMessage(new MessageParams(MessageType.Info, "Position=" + caretPosition));
         server.getClient().showMessage(new MessageParams(MessageType.Info, "completionItems = " + completionItems));
 
         return completionItems;
+    }
+
+    /** Converts a document URI to a filesystem path, or null for non-file URIs. */
+    private static Path toPath(String uri) {
+        try {
+            return Paths.get(URI.create(uri));
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 import org.drools.completion.ClassIndex;
 import org.drools.completion.ClassMemberIndex;
+import org.drools.completion.DRLDeclaredTypeParser;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -67,6 +68,9 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
             textService.setClassIndex(ClassIndex.merge(jarClassIndex, outputIndex));
             // Fresh loader so recompiled classes aren't served from the old one's cache.
             swapMemberIndex(ClassMemberIndex.of(classpathEntries));
+            // Drop the declared-type parse cache so edited sibling files re-parse
+            // and the cache doesn't grow unbounded over the server's lifetime.
+            DRLDeclaredTypeParser.clearCache();
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to rebuild class index", e);
         }
@@ -154,6 +158,7 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
         } catch (Exception e) {
             logger.log(Level.FINE, "Failed to close class member index on shutdown", e);
         }
+        DRLDeclaredTypeParser.clearCache();
         return CompletableFuture.completedFuture(null);
     }
 


### PR DESCRIPTION
Update type resolution to include DRL-declared types outside of the current file.

Stacked on and dependent upon #79 