### PR TITLE
fix: index project's own classes before Maven dependency resolution

### DIFF
--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/DroolsLspServer.java
@@ -144,6 +144,18 @@ public class DroolsLspServer implements LanguageServer, LanguageClientAware {
             CompletableFuture.runAsync(() -> {
                 try {
                     Path rootPath = Paths.get(URI.create(rootUri));
+
+                    // Publish the project's own compiled classes first. This only
+                    // scans the filesystem (no mvn), so type-relianlt features are
+                    // available within milliseconds rather than waiting on the
+                    // dependency-JAR resolution below — which shells out to mvn and
+                    // can take many seconds.
+                    Set<Path> outputDirs = MavenClasspathResolver.resolveBuildOutputDirs(rootPath);
+                    buildOutputDirs = outputDirs;
+                    textService.setClassIndex(ClassIndex.build(outputDirs));
+
+                    // Then resolve the full classpath (dependency JARs via mvn) and
+                    // merge, so features reliant on this become available subsequently.
                     Set<Path> resolved = MavenClasspathResolver.resolve(rootPath);
                     setResolvedClasspath(resolved);
                     ClassIndex outputIndex = ClassIndex.build(buildOutputDirs);

--- a/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
+++ b/drools-lsp-server/src/main/java/org/drools/lsp/server/MavenClasspathResolver.java
@@ -39,6 +39,22 @@ public class MavenClasspathResolver {
         return classpathEntries;
     }
 
+    /**
+     * Returns only the modules' compiled-output directories (target/classes and
+     * the like), located via filesystem conventions without invoking {@code mvn}.
+     *
+     * <p>This is the fast half of {@link #resolve(Path)}: it lets the server index
+     * the project's own classes immediately, before the slower dependency-JAR
+     * resolution (which shells out to {@code mvn}) has completed.
+     */
+    public static Set<Path> resolveBuildOutputDirs(Path rootDir) {
+        Set<Path> dirs = new LinkedHashSet<>();
+        for (Path pom : findPomFiles(rootDir)) {
+            dirs.addAll(BuildOutputLocator.findClassDirs(pom.getParent()));
+        }
+        return dirs;
+    }
+
     static List<Path> findPomFiles(Path rootDir) {
         List<Path> result = new ArrayList<>();
         try {

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/MavenClasspathResolverTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/MavenClasspathResolverTest.java
@@ -43,6 +43,21 @@ class MavenClasspathResolverTest {
     }
 
     @Test
+    void resolveBuildOutputDirsReturnsClassDirsWithoutInvokingMaven() throws IOException {
+        // A minimal project with compiled output but no resolvable dependencies.
+        // The build-output dirs must come back from the filesystem alone (no mvn),
+        // so the server can index the project's own classes before the slower
+        // dependency-JAR resolution runs.
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path classes = tempDir.resolve("target/classes");
+        Files.createDirectories(classes);
+
+        Set<Path> dirs = MavenClasspathResolver.resolveBuildOutputDirs(tempDir);
+
+        assertThat(dirs).contains(classes);
+    }
+
+    @Test
     void resolveReturnsClasspathEntriesForRealProject() {
         Path projectRoot = Path.of(System.getProperty("user.dir")).getParent();
         if (!Files.exists(projectRoot.resolve("pom.xml"))) {


### PR DESCRIPTION
Hopefully fixes the MacOS E2E test which is often failling.

The startup class index was published only after MavenClasspathResolver.resolve() returned, and resolve() shells out to `mvn dependency:build-classpath` (up to a 60s timeout per module) before returning. On slower runners the project's own compiled classes weren't indexed within the completion E2E test's ~15s poll window, so the macOS "Suggests class names in pattern position" test failed while Linux/Windows passed.

Publish the build-output class index first via the new mvn-free resolveBuildOutputDirs(), then resolve dependency JARs and merge. Own-type completion is now available within milliseconds, independent of mvn speed.